### PR TITLE
Renamed the haas.api_server module to haas.server.

### DIFF
--- a/haas/api.py
+++ b/haas/api.py
@@ -1,6 +1,6 @@
 """This module provides the HaaS service's public API.
 
-haas.api_server translates between this and HTTP.
+haas.server translates between this and HTTP.
 
 TODO: Spec out and document what sanitization is required.
 """

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -34,9 +34,9 @@ def object_url(typename, objname):
 @cmd
 def serve(*args):
     """Start the HaaS API server."""
-    from haas import model, api_server
+    from haas import model, server
     model.init_db()
-    api_server.app.run(debug=True)
+    server.app.run(debug=True)
 
 
 @cmd

--- a/haas/server.py
+++ b/haas/server.py
@@ -3,13 +3,7 @@
 This module only marshalls between HTTP and the routines in haas.api; it doesn't
 directly ipmlement the semantics of the API.
 
-To start the server, or the module can be run as a script, e.g. (from the root
-of the source tree):
-
-    python haas/api_server.py
-
-Right now the server is always run in debug mode, which isn't safe for
-production use. When we get close to release-quality we'll have to change this.
+To start the server, invoke `haas serve` from the command line.
 """
 
 from flask import Flask, request


### PR DESCRIPTION
We all agreed on Friday that the name needed to change; I think this is
a reasonable solution.

One of the docstrings had a reference to api_server in a section that
was otherwise out of date. Rather than simply adjusting the name, I
updated the docstring to match the current situation.
