### PR TITLE
Got rid of deprecated available bit on model.Node.

### DIFF
--- a/haas/api.py
+++ b/haas/api.py
@@ -726,7 +726,7 @@ def port_detach_nic(switch_name, port_name):
 @rest_call('GET', '/free_nodes')
 def list_free_nodes():
     db = model.Session()
-    nodes = db.query(model.Node).filter_by(available=True).all()
+    nodes = db.query(model.Node).filter_by(project_id=None).all()
     nodes = map(lambda n: n.label, nodes)
     return json.dumps(nodes)
 
@@ -737,7 +737,7 @@ def show_node(nodename):
     node = _must_find(db, model.Node, nodename)
     return json.dumps({
         'name': node.label,
-        'free': node.available,
+        'free': node.project_id is None,
         'nics': map(lambda n: n.label, node.nics),
     })
 

--- a/haas/model.py
+++ b/haas/model.py
@@ -72,7 +72,6 @@ class Nic(Model):
 
 
 class Node(Model):
-    available     = Column(Boolean)
     project_id    = Column(Integer,ForeignKey('project.id'))
     #many to one mapping to project
     project       = relationship("Project",backref=backref('nodes'))


### PR DESCRIPTION
Its presence threw me when writing the query api stuff; other things
aren't using it, but checking if project_id is null. I wrote some tests,
removed the attribute, and made the appropriate fixes.
