### PR TITLE
Fix erroneous example instructions in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,8 @@ for the various API commands one can test.  Here is an example session,
 testing ``headnode_delete_hnic``::
 
   haas group_create gp
-  haas headnode_create hn gp
+  haas project_create proj gp
+  haas headnode_create hn proj
   haas headnode_create_hnic hn hn-eth0 DE:AD:BE:EF:20:12
   haas headnode_delete_hnic hn hn-eth0
 


### PR DESCRIPTION
When we changed the headnode creation API, we didn't update the example commands in the README
