### PR TITLE
Check that HNIC is attached before attaching to bridge

### DIFF
--- a/haas/model.py
+++ b/haas/model.py
@@ -247,6 +247,10 @@ class Hnic(Model):
 
     @no_dry_run
     def create(self):
+        if not self.network:
+            # It is non-trivial to make a NIC not connected to a network, so
+            # do nothing at all instead.
+            return
         trunk_nic = cfg.get('headnode', 'trunk_nic')
         vlan_no = str(self.network.network_id)
         bridge = 'br-vlan%s' % vlan_no


### PR DESCRIPTION
Previously, the code would attempt to attach the HNIC to a network, and hit a
null dereference if it wasn't attached.  Now it simply skips creating the
HNIC.  It might be nice to create the HNIC but not attach it, but it's a
little harder to do that.

This fixes #195
