### PR TITLE
Fixed a typo in a check_status_code invocation.

### DIFF
--- a/haas/cli.py
+++ b/haas/cli.py
@@ -184,7 +184,7 @@ def headnode_start(headnode):
 def headnode_stop(headnode):
     """Stop <headnode>"""
     url = object_url('headnode', headnode, 'stop')
-    check_stauts_code(requests.post(url))
+    check_status_code(requests.post(url))
 
 @cmd
 def node_register(node):


### PR DESCRIPTION
Small typo in cli.py was causing headnode_stop to throw an exception.
