### PR TITLE
Use a fresh UUID for vm name, rather than SQL id

### DIFF
--- a/haas/model.py
+++ b/haas/model.py
@@ -167,7 +167,7 @@ class Headnode(Model):
     dirty = Column(Boolean, nullable=False)
 
     # We need a guaranteed unique name to generate the libvirt machine name
-    uuid = Column(String, nullable=False)
+    uuid = Column(String, nullable=False, unique=True)
 
     def __init__(self, project, label):
         self.project = project


### PR DESCRIPTION
This makes the VM names globally unique, allowing multiple different instances
of the haas to share a headnode host.  It also fixes #123.
