### PR TITLE
.gitignore all *.cfg files, not just haas.cfg.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ dist
 .venv
 .coverage
 *.db
-haas.cfg
+*.cfg


### PR DESCRIPTION
We may start using these on other branches, let's make sure they don't
get committed accidentally.
