### PR TITLE
Add importlib to requirements. Meets unmet dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flask
 sqlalchemy
 Flask-HTTPAuth
+importlib
 passlib
 pexpect
 tabulate


### PR DESCRIPTION
Fix error encountered on Centos 6.5 during "haas init_db":

$ haas init_db
Traceback (most recent call last):
  File "/home/henn/.venv/bin/haas", line 8, in <module>
    execfile(**file**)
  File "/home/henn/repo/haas/scripts/haas", line 18, in <module>
    cli.main()
  File "/home/henn/repo/haas/haas/cli.py", line 359, in main
    command_dict[sys.argv[1]](*sys.argv[2:])
  File "/home/henn/repo/haas/haas/cli.py", line 41, in wrapped
    f(_args, *_kwargs)
  File "/home/henn/repo/haas/haas/cli.py", line 89, in init_db
    from haas import model
  File "/home/henn/repo/haas/haas/model.py", line 23, in <module>
    import importlib
ImportError: No module named importlib
