### PR TITLE
Fix syntax error in site-layout.json.example

### DIFF
--- a/site-layout.json.example
+++ b/site-layout.json.example
@@ -14,6 +14,7 @@
                     "name": "nic2",
                     "mac" : "de:ad:be:ef:20:15",
                     "port": "gi1/0/2"
+		}
             ],
             "ipmi": {
                 "host": "192.168.1.1",


### PR DESCRIPTION
I thought we'd fixed this already...
