### PR TITLE
Added handling for non-ascii chars in console log

### DIFF
--- a/haas/model.py
+++ b/haas/model.py
@@ -204,12 +204,10 @@ class Node(Model):
             os.remove(self.get_console_log_filename())
 
     def get_console(self):
-        def removeNonAscii(s): 
-            return "".join(i for i in s if ord(i)<128)
         if not os.path.isfile(self.get_console_log_filename()):
             return None
         with open(self.get_console_log_filename(), 'r') as log:
-            return removeNonAscii(log.read())
+            return "".join(i for i in log.read() if ord(i)<128)
 
     def get_console_log_filename(self):
         return '/var/run/haas_console_logs/%s.log' % self.ipmi_host


### PR DESCRIPTION
HaaS would crash when trying to read non-ascii characters from the log.  This patch removes the non-ascii characters.
