### PR TITLE
Set 'dry_run' in simple vlan tests

### DIFF
--- a/tests/unit/drivers/simple_vlan.py
+++ b/tests/unit/drivers/simple_vlan.py
@@ -39,6 +39,8 @@ def vlan_test(vlan_list):
             cfg.set('vlan', 'vlans', vlan_list)
             cfg.add_section('driver simple_vlan')
             cfg.set('driver simple_vlan', 'switch', '{"switch":"null"}')
+            cfg.add_section('devel')
+            cfg.set('devel', 'dry_run')
 
         @wraps(f)
         @clear_configuration


### PR DESCRIPTION
This fixes a failed test.
