### PR TITLE
Fixed erroneous calls to network_create in deployment tests

### DIFF
--- a/tests/deployment/deployment.py
+++ b/tests/deployment/deployment.py
@@ -32,7 +32,7 @@ class TestHeadNode:
     def test_headnode_start(self, db):
         api.group_create('acme-code')
         api.project_create('anvil-nextgen', 'acme-code')
-        api.network_create('spider-web', 'anvil-nextgen')
+        network_create_simple('spider-web', 'anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hnic-0')
         api.headnode_connect_network('hn-0', 'hnic-0', 'spider-web')
@@ -78,8 +78,8 @@ class TestNetwork:
                     'provided.') % len(nodes))
 
             # Create two networks
-            api.network_create('net-0', 'anvil-nextgen')
-            api.network_create('net-1', 'anvil-nextgen')
+            network_create_simple('net-0', 'anvil-nextgen')
+            network_create_simple('net-1', 'anvil-nextgen')
 
             # Convert each node to a dict for ease of access
             nodes = [{'label': n.label,


### PR DESCRIPTION
These were overlooked when Fancy Networks was merged (#275).
