### PR TITLE
Update url field in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [str(r.req) for r in parse_requirements('requirements.txt')]
 
 setup(name='haas',
       version='1.0',
-      url='https://github.com/CCI-MOC/moc-public',
+      url='https://github.com/CCI-MOC/haas',
       packages=find_packages(),
       scripts=['scripts/haas', 'scripts/create_bridges'],
       install_requires=requirements,


### PR DESCRIPTION
Looks like this was never changed when we renamed the repo.
