### PR TITLE
Remove groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,7 @@ init_db``.  Run the server with ``haas serve``.  Finally, see ``haas help``
 for the various API commands one can test.  Here is an example session,
 testing ``headnode_delete_hnic``::
 
-  haas group_create gp
-  haas project_create proj gp
+  haas project_create proj
   haas headnode_create hn proj
   haas headnode_create_hnic hn hn-eth0 DE:AD:BE:EF:20:12
   haas headnode_delete_hnic hn hn-eth0

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -8,14 +8,9 @@ Full Api spec:
     [PUT]    /user/<user_label> {password=<password>}
     [DELETE] /user/<user_label>
 
-    group_add_user    <group_label> <user_label>
-    group_remove_user <group_label> <user_label>
-    [POST] /group/<group_label>/add_user {user=<user_label>}
-    [POST] /group/<group_label>/remove_user {user=<user_label>}
-
-    project_create <project_label> <group_label>
+    project_create <project_label>
     project_delete <project_label>
-    [PUT]    /project/<project_label> {group=<group_label>}
+    [PUT]    /project/<project_label>
     [DELETE] /project/<project_label>
 
     network_create <network_label> <proj_creator> <proj_access> <net_id>

--- a/haas/api.py
+++ b/haas/api.py
@@ -99,82 +99,20 @@ def user_delete(user):
     db.delete(user)
     db.commit()
 
-                            # Group Code #
-                            ##############
-
-
-@rest_call('PUT', '/group/<group>')
-def group_create(group):
-    """Create group.
-
-    If the group already exists, a DuplicateError will be raised.
-    """
-    db = model.Session()
-    _assert_absent(db, model.Group, group)
-    group = model.Group(group)
-    db.add(group)
-    db.commit()
-
-
-@rest_call('DELETE', '/group/<group>')
-def group_delete(group):
-    """Delete group.
-
-    If the group does not exist, a NotFoundError will be raised.
-    """
-    db = model.Session()
-    group = _must_find(db, model.Group, group)
-    db.delete(group)
-    db.commit()
-
-
-@rest_call('POST', '/group/<group>/add_user')
-def group_add_user(group, user):
-    """Add a user to a group.
-
-    If the group or user does not exist, a NotFoundError will be raised.
-    """
-    db = model.Session()
-    user = _must_find(db, model.User, user)
-    group = _must_find(db, model.Group, group)
-    if group in user.groups:
-        raise DuplicateError('User %s is already in group %s',
-                             (user.label, group.label))
-    user.groups.append(group)
-    db.commit()
-
-
-@rest_call('POST', '/group/<group>/remove_user')
-def group_remove_user(group, user):
-    """Remove a user from a group.
-
-    If the group or user does not exist, a NotFoundError will be raised.
-    """
-    db = model.Session()
-    user = _must_find(db, model.User, user)
-    group = _must_find(db, model.Group, group)
-    if group not in user.groups:
-        raise NotFoundError("User %s is not in group %s",
-                            (user.label, group.label))
-    user.groups.remove(group)
-    db.commit()
 
                             # Project Code #
                             ################
 
 
 @rest_call('PUT', '/project/<project>')
-def project_create(project, group):
-    """Create project belonging to the given group.
+def project_create(project):
+    """Create a project.
 
     If the project already exists, a DuplicateError will be raised.
-
-    If the group does not exist, a NotFoundError will be raised.
     """
     db = model.Session()
     _assert_absent(db, model.Project, project)
-    group = _must_find(db, model.Group, group)
-    project = model.Project(group, project)
+    project = model.Project(project)
     db.add(project)
     db.commit()
 
@@ -238,6 +176,38 @@ def project_detach_node(project, node):
     node.stop_console()
     node.delete_console()
     project.nodes.remove(node)
+    db.commit()
+
+
+@rest_call('POST', '/project/<project>/add_user')
+def project_add_user(project, user):
+    """Add a user to a project.
+
+    If the project or user does not exist, a NotFoundError will be raised.
+    """
+    db = model.Session()
+    user = _must_find(db, model.User, user)
+    project = _must_find(db, model.Project, project)
+    if project in user.projects:
+        raise DuplicateError('User %s is already in project %s',
+                             (user.label, project.label))
+    user.projects.append(project)
+    db.commit()
+
+
+@rest_call('POST', '/project/<project>/remove_user')
+def project_remove_user(project, user):
+    """Remove a user from a project.
+
+    If the project or user does not exist, a NotFoundError will be raised.
+    """
+    db = model.Session()
+    user = _must_find(db, model.User, user)
+    project = _must_find(db, model.Project, project)
+    if project not in user.projects:
+        raise NotFoundError("User %s is not in project %s",
+                            (user.label, project.label))
+    user.projects.remove(project)
     db.commit()
 
 

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -133,39 +133,27 @@ def user_delete(username):
     check_status_code(requests.delete(url))
 
 @cmd
-def group_add_user(group, user):
-    """Add <user> to <group>"""
-    url = object_url('group', group, 'add_user')
+def project_add_user(project, user):
+    """Add <user> to <project>"""
+    url = object_url('project', project, 'add_user')
     check_status_code(requests.post(url, data={'user': user}))
 
 @cmd
-def group_remove_user(group, user):
-    """Remove <user> from <group>"""
-    url = object_url('group', group, 'remove_user')
+def project_remove_user(project, user):
+    """Remove <user> from <project>"""
+    url = object_url('project', project, 'remove_user')
     check_status_code(requests.post(url, data={'user': user}))
 
 @cmd
-def project_create(project, group):
-    """Create <project> belonging to <group>"""
+def project_create(project):
+    """Create a <project>"""
     url = object_url('project', project)
-    check_status_code(requests.put(url, data={'group': group}))
+    check_status_code(requests.put(url))
 
 @cmd
 def project_delete(project):
     """Delete <project>"""
     url = object_url('project', project)
-    check_status_code(requests.delete(url))
-
-@cmd
-def group_create(group):
-    """Create <group>"""
-    url = object_url('group', group)
-    check_status_code(requests.put(url))
-
-@cmd
-def group_delete(group):
-    """Delete <group>"""
-    url = object_url('group', group)
     check_status_code(requests.delete(url))
 
 @cmd

--- a/tests/deployment/deployment.py
+++ b/tests/deployment/deployment.py
@@ -43,8 +43,7 @@ class TestHeadNode:
     @deployment_test
     @headnode_cleanup
     def test_headnode(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         network_create_simple('spider-web', 'anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hnic-0')
@@ -58,8 +57,7 @@ class TestHeadNode:
     @deployment_test
     @headnode_cleanup
     def test_headnode_deletion_while_running(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_start('hn-0')
         api.headnode_delete('hn-0')
@@ -156,9 +154,8 @@ class TestNetwork:
             api.network_delete('net-0')
             api.network_delete('net-1')
 
-        # Create group and project
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        # Create a project
+        api.project_create('anvil-nextgen')
 
         create_networks()
         delete_networks()

--- a/tests/unit/api.py
+++ b/tests/unit/api.py
@@ -20,65 +20,6 @@ import pytest
 import json
 
 
-class TestGroup:
-    """Tests for the haas.api.group_* functions."""
-
-    # Several basic tests, functions should succeed in trivial cases.
-    @database_only
-    def test_group_create(self, db):
-        api.group_create('acme-corp')
-        api._must_find(db, model.Group, 'acme-corp')
-
-    @database_only
-    def test_group_add_user(self, db):
-        api.user_create('alice', 'secret')
-        api.group_create('acme-corp')
-        api.group_add_user('acme-corp', 'alice')
-        user = api._must_find(db, model.User, 'alice')
-        group = api._must_find(db, model.Group, 'acme-corp')
-        assert group in user.groups
-        assert user in group.users
-
-    @database_only
-    def test_group_remove_user(self, db):
-        api.user_create('alice', 'secret')
-        api.group_create('acme-corp')
-        api.group_add_user('acme-corp', 'alice')
-        api.group_remove_user('acme-corp', 'alice')
-        user = api._must_find(db, model.User, 'alice')
-        group = api._must_find(db, model.Group, 'acme-corp')
-        assert group not in user.groups
-        assert user not in group.users
-
-    @database_only
-    def test_group_delete(self, db):
-        api.group_create('acme-corp')
-        api.group_delete('acme-corp')
-        with pytest.raises(api.NotFoundError):
-            api._must_find(db, model.Group, 'acme-corp')
-
-    @database_only
-    def test_duplicate_group_create(self, db):
-        api.group_create('acme-corp')
-        with pytest.raises(api.DuplicateError):
-            api.group_create('acme-corp')
-
-    @database_only
-    def test_duplicate_group_add_user(self, db):
-        api.user_create('alice', 'secret')
-        api.group_create('acme-corp')
-        api.group_add_user('acme-corp', 'alice')
-        with pytest.raises(api.DuplicateError):
-            api.group_add_user('acme-corp', 'alice')
-
-    @database_only
-    def test_bad_group_remove_user(self, db):
-        """Tests that removing a user from a group they're not in fails."""
-        api.user_create('alice', 'secret')
-        api.group_create('acme-corp')
-        with pytest.raises(api.NotFoundError):
-            api.group_remove_user('acme-corp', 'alice')
-
 class TestUser:
     """Tests for the haas.api.user_* functions."""
 
@@ -116,21 +57,18 @@ class TestProjectCreateDelete:
 
     @database_only
     def test_project_create_success(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api._must_find(db, model.Project, 'anvil-nextgen')
 
     @database_only
     def test_project_create_duplicate(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         with pytest.raises(api.DuplicateError):
-            api.project_create('anvil-nextgen', 'acme-corp')
+            api.project_create('anvil-nextgen')
 
     @database_only
     def test_project_delete(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.project_delete('anvil-nextgen')
         with pytest.raises(api.NotFoundError):
             api._must_find(db, model.Project, 'anvil-nextgen')
@@ -143,8 +81,7 @@ class TestProjectCreateDelete:
     @database_only
     def test_project_delete_hasnode(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         with pytest.raises(api.BlockedError):
             api.project_delete('anvil-nextgen')
@@ -152,35 +89,84 @@ class TestProjectCreateDelete:
     @database_only
     def test_project_delete_success_nodesdeleted(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.project_detach_node('anvil-nextgen', 'node-99')
         api.project_delete('anvil-nextgen')
 
     @database_only
     def test_project_delete_hasnetwork(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
         with pytest.raises(api.BlockedError):
             api.project_delete('anvil-nextgen')
 
     @database_only
     def test_project_delete_success_networksdeleted(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.network_delete('hammernet')
         api.project_delete('anvil-nextgen')
 
     @database_only
     def test_project_delete_hasheadnode(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-01', 'anvil-nextgen')
         with pytest.raises(api.BlockedError):
             api.project_delete('anvil-nextgen')
+
+class TestProjectAddDeleteUser:
+    """Tests for adding and deleting a user from a project"""
+
+    @database_only
+    def test_project_add_user(self, db):
+        api.user_create('alice', 'secret')
+        api.project_create('acme-corp')
+        api.project_add_user('acme-corp', 'alice')
+        user = api._must_find(db, model.User, 'alice')
+        project = api._must_find(db, model.Project, 'acme-corp')
+        assert project in user.projects
+        assert user in project.users
+
+    @database_only
+    def test_project_remove_user(self, db):
+        api.user_create('alice', 'secret')
+        api.project_create('acme-corp')
+        api.project_add_user('acme-corp', 'alice')
+        api.project_remove_user('acme-corp', 'alice')
+        user = api._must_find(db, model.User, 'alice')
+        project = api._must_find(db, model.Project, 'acme-corp')
+        assert project not in user.projects
+        assert user not in project.users
+
+    @database_only
+    def test_project_delete(self, db):
+        api.project_create('acme-corp')
+        api.project_delete('acme-corp')
+        with pytest.raises(api.NotFoundError):
+            api._must_find(db, model.Project, 'acme-corp')
+
+    @database_only
+    def test_duplicate_project_create(self, db):
+        api.project_create('acme-corp')
+        with pytest.raises(api.DuplicateError):
+            api.project_create('acme-corp')
+
+    @database_only
+    def test_duplicate_project_add_user(self, db):
+        api.user_create('alice', 'secret')
+        api.project_create('acme-corp')
+        api.project_add_user('acme-corp', 'alice')
+        with pytest.raises(api.DuplicateError):
+            api.project_add_user('acme-corp', 'alice')
+
+    @database_only
+    def test_bad_project_remove_user(self, db):
+        """Tests that removing a user from a project they're not in fails."""
+        api.user_create('alice', 'secret')
+        api.project_create('acme-corp')
+        with pytest.raises(api.NotFoundError):
+            api.project_remove_user('acme-corp', 'alice')
 
 
 class TestNetworking:
@@ -201,8 +187,7 @@ class TestNetworking:
         api.port_connect_nic('switch', '2', 'node-98', 'eth0')
         api.port_connect_nic('switch', '3', 'node-97', 'eth0')
 
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.project_connect_node('anvil-nextgen', 'node-98')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -214,8 +199,7 @@ class TestNetworking:
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
 
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
 
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -226,8 +210,7 @@ class TestProjectConnectDetachNode:
 
     @database_only
     def test_project_connect_node(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.project_connect_node('anvil-nextgen', 'node-99')
         project = api._must_find(db, model.Project, 'anvil-nextgen')
@@ -245,15 +228,13 @@ class TestProjectConnectDetachNode:
     @database_only
     def test_project_connect_node_node_nexist(self, db):
         """Tests that connecting a nonexistent node to a projcet fails"""
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         with pytest.raises(api.NotFoundError):
             api.project_connect_node('anvil-nextgen', 'node-99')
 
     @database_only
     def test_project_detach_node(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.project_detach_node('anvil-nextgen', 'node-99')
@@ -265,8 +246,7 @@ class TestProjectConnectDetachNode:
     @database_only
     def test_project_detach_node_notattached(self, db):
         """Tests that removing a node from a project it's not in fails."""
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         with pytest.raises(api.NotFoundError):
             api.project_detach_node('anvil-nextgen', 'node-99')
@@ -281,15 +261,13 @@ class TestProjectConnectDetachNode:
     @database_only
     def test_project_detach_node_node_nexist(self, db):
         """Tests that removing a nonexistent node from a project fails."""
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         with pytest.raises(api.NotFoundError):
             api.project_detach_node('anvil-nextgen', 'node-99')
 
     @database_only
     def test_project_detach_node_on_network(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
@@ -300,8 +278,7 @@ class TestProjectConnectDetachNode:
 
     @database_only
     def test_project_detach_node_success_nic_not_on_network(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
@@ -310,8 +287,7 @@ class TestProjectConnectDetachNode:
 
     @database_only
     def test_project_detach_node_removed_from_network(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
@@ -419,8 +395,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_success(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 
@@ -434,8 +409,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_wrong_node_in_project(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -449,8 +423,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_wrong_node_not_in_project(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_register('node-98', 'ipmihost', 'root', 'tapeworm') # added
@@ -462,8 +435,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_no_such_node(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 
@@ -474,8 +446,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_no_such_nic(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
 #        api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 
@@ -486,8 +457,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_no_such_network(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
 #        network_create_simple('hammernet', 'anvil-nextgen')
         with pytest.raises(api.NotFoundError):
@@ -497,8 +467,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_node_not_in_project(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
 #        api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 
@@ -509,9 +478,8 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_different_projects(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
-        api.project_create('anvil-oldtimer', 'acme-code') # added
+        api.project_create('anvil-nextgen')
+        api.project_create('anvil-oldtimer') # added
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-oldtimer') # changed
 
@@ -522,8 +490,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_already_attached_to_same(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_connect_network('node-99', '99-eth0', 'hammernet') # added
@@ -534,8 +501,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_connect_network_already_attached_differently(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         network_create_simple('hammernet2', 'anvil-nextgen') #added
@@ -548,8 +514,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_detach_network_success(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -564,8 +529,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_detach_network_not_attached(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 #        api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -577,8 +541,7 @@ class TestNodeConnectDetachNetwork:
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register('node-98', 'ipmihost', 'root', 'tapeworm') # added
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.project_connect_node('anvil-nextgen', 'node-98') # added
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -592,8 +555,7 @@ class TestNodeConnectDetachNetwork:
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register('node-98', 'ipmihost', 'root', 'tapeworm') # added
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -605,8 +567,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_detach_network_no_such_node(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -618,8 +579,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_detach_network_no_such_nic(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -631,8 +591,7 @@ class TestNodeConnectDetachNetwork:
     def test_node_detach_network_node_not_in_project(self, db):
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
 #        api.project_connect_node('anvil-nextgen', 'node-99')
 #        network_create_simple('hammernet', 'anvil-nextgen')
 #        api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -645,24 +604,22 @@ class TestHeadnodeCreateDelete:
 
     @database_only
     def test_headnode_create_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         hn = api._must_find(db, model.Headnode, 'hn-0')
         assert hn.project.label == 'anvil-nextgen'
 
     @database_only
     def test_headnode_create_badproject(self, db):
-        """Tests that creating a headnode with a nonexistent group fails"""
+        """Tests that creating a headnode with a nonexistent project fails"""
         with pytest.raises(api.NotFoundError):
             api.headnode_create('hn-0', 'anvil-nextgen')
 
     @database_only
     def test_headnode_create_duplicate(self, db):
         """Tests that creating a headnode with a duplicate name fails"""
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
-        api.project_create('anvil-oldtimer', 'acme-code')
+        api.project_create('anvil-nextgen')
+        api.project_create('anvil-oldtimer')
         api.headnode_create('hn-0', 'anvil-nextgen')
         with pytest.raises(api.DuplicateError):
             api.headnode_create('hn-0', 'anvil-oldtimer')
@@ -670,16 +627,14 @@ class TestHeadnodeCreateDelete:
     @database_only
     def test_headnode_create_second(self, db):
         """Tests that creating a second headnode one one project fails"""
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create('hn-1', 'anvil-nextgen')
 
 
     @database_only
     def test_headnode_delete_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_delete('hn-0')
         api._assert_absent(db, model.Headnode, 'hn-0')
@@ -695,8 +650,7 @@ class TestHeadnodeCreateDeleteHnic:
 
     @database_only
     def test_headnode_create_hnic_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         nic = api._must_find(db, model.Hnic, 'hn-0-eth0')
@@ -709,8 +663,7 @@ class TestHeadnodeCreateDeleteHnic:
 
     @database_only
     def test_headnode_create_hnic_duplicate_hnic(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         with pytest.raises(api.DuplicateError):
@@ -718,8 +671,7 @@ class TestHeadnodeCreateDeleteHnic:
 
     @database_only
     def test_headnode_delete_hnic_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         api.headnode_delete_hnic('hn-0', 'hn-0-eth0')
@@ -728,8 +680,7 @@ class TestHeadnodeCreateDeleteHnic:
 
     @database_only
     def test_headnode_delete_hnic_hnic_nexist(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         with pytest.raises(api.NotFoundError):
             api.headnode_delete_hnic('hn-0', 'hn-0-eth0')
@@ -741,9 +692,8 @@ class TestHeadnodeCreateDeleteHnic:
 
     @database_only
     def test_headnode_delete_hnic_wrong_headnode(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
-        api.project_create('anvil-oldtimer', 'acme-code')
+        api.project_create('anvil-nextgen')
+        api.project_create('anvil-oldtimer')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create('hn-1', 'anvil-oldtimer')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
@@ -752,8 +702,7 @@ class TestHeadnodeCreateDeleteHnic:
 
     @database_only
     def test_headnode_delete_hnic_wrong_nexist_headnode(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         with pytest.raises(api.NotFoundError):
@@ -761,9 +710,8 @@ class TestHeadnodeCreateDeleteHnic:
 
     @database_only
     def test_headnode_create_hnic_diff_headnodes(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-legacy', 'acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-legacy')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-legacy')
         api.headnode_create('hn-1', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'eth0')
@@ -774,8 +722,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_connect_network_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -788,8 +735,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_connect_network_no_such_headnode(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -799,8 +745,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_connect_network_no_such_hnic(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -810,8 +755,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_connect_network_no_such_network(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -821,8 +765,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_connect_network_already_attached_to_same(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -832,8 +775,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_connect_network_already_attached_differently(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -844,9 +786,8 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_connect_network_different_projects(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
-        api.project_create('anvil-oldtimer', 'acme-code') # added
+        api.project_create('anvil-nextgen')
+        api.project_create('anvil-oldtimer') # added
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-oldtimer') #changed
@@ -857,8 +798,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_detach_network_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -872,8 +812,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_detach_network_not_attached(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -883,8 +822,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_detach_network_no_such_headnode(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -895,8 +833,7 @@ class TestHeadnodeConnectDetachNetwork:
 
     @database_only
     def test_headnode_detach_network_no_such_hnic(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -919,8 +856,7 @@ class TestHeadnodeFreeze:
 
     def _prep(self):
         """Helper to set up common state."""
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
 
     def _prep_delete_hnic(self):
@@ -998,8 +934,7 @@ class TestNetworkCreateDelete:
 
     @database_only
     def test_network_create_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
         net = api._must_find(db, model.Network, 'hammernet')
         assert net.creator.label == 'anvil-nextgen'
@@ -1013,25 +948,22 @@ class TestNetworkCreateDelete:
     @database_only
     def test_network_create_duplicate(self, db):
         """Tests that creating a network with a duplicate name fails"""
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
-        api.project_create('anvil-oldtimer', 'acme-code')
+        api.project_create('anvil-nextgen')
+        api.project_create('anvil-oldtimer')
         network_create_simple('hammernet', 'anvil-nextgen')
         with pytest.raises(api.DuplicateError):
             network_create_simple('hammernet', 'anvil-oldtimer')
 
     @database_only
     def test_network_delete_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.network_delete('hammernet')
         api._assert_absent(db, model.Network, 'hammernet')
 
     @database_only
     def test_network_delete_project_complex_success(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
@@ -1048,8 +980,7 @@ class TestNetworkCreateDelete:
 
     @database_only
     def test_network_delete_node_on_network(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
@@ -1060,8 +991,7 @@ class TestNetworkCreateDelete:
 
     @database_only
     def test_network_delete_headnode_on_network(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen')
         api.headnode_create_hnic('hn-0', 'eth0')
@@ -1286,8 +1216,7 @@ class TestQuery:
         api.node_register('robocop', 'ipmihost', 'root', 'tapeworm')
         api.node_register('data', 'ipmihost', 'root', 'tapeworm')
 
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'robocop')
         api.project_connect_node('anvil-nextgen', 'data')
 
@@ -1323,8 +1252,7 @@ class TestQuery:
         api.node_register_nic('robocop', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('robocop', 'wlan0', 'DE:AD:BE:EF:20:15')
 
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'robocop')
 
         actual = json.loads(api.show_node('robocop'))
@@ -1355,8 +1283,7 @@ class TestQuery:
         api.node_register('robocop', 'ipmihost', 'root', 'tapeworm')
         api.node_register('data', 'ipmihost', 'root', 'tapeworm')
 
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'master-control-program')
         api.project_connect_node('anvil-nextgen', 'robocop')
         api.project_connect_node('anvil-nextgen', 'data')
@@ -1371,8 +1298,7 @@ class TestQuery:
 
     @database_only
     def test_no_project_nodes(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         assert json.loads(api.list_project_nodes('anvil-nextgen')) == []
 
     @database_only
@@ -1382,8 +1308,7 @@ class TestQuery:
         api.node_register('robocop', 'ipmihost', 'root', 'tapeworm')
         api.node_register('data', 'ipmihost', 'root', 'tapeworm')
 
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'robocop')
         api.project_connect_node('anvil-nextgen', 'data')
 
@@ -1393,8 +1318,7 @@ class TestQuery:
 
     @database_only
     def test_project_list_networks(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
 
         network_create_simple('pxe', 'anvil-nextgen')
         network_create_simple('public', 'anvil-nextgen')
@@ -1411,15 +1335,13 @@ class TestQuery:
 
     @database_only
     def test_no_project_networks(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         assert json.loads(api.list_project_nodes('anvil-nextgen')) == []
 
 
     @database_only
     def test_show_headnode(self, db):
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         network_create_simple('spiderwebs', 'anvil-nextgen')
         api.headnode_create('BGH', 'anvil-nextgen')
         api.headnode_create_hnic('BGH', 'eth0')
@@ -1460,8 +1382,7 @@ class TestFancyNetworkCreate:
     @database_only
     def test_project_network(self, db):
         """Succesfully create a project-owned network."""
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         api.network_create('hammernet', 'anvil-nextgen', 'anvil-nextgen', '')
         project = api._must_find(db, model.Project, 'anvil-nextgen')
         network = api._must_find(db, model.Network, 'hammernet')
@@ -1472,17 +1393,15 @@ class TestFancyNetworkCreate:
     @database_only
     def test_project_network_imported_fails(self, db):
         """Fail to make a project-owned network with a supplied net-id."""
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         with pytest.raises(api.BadArgumentError):
             api.network_create('hammernet', 'anvil-nextgen', 'anvil-nextgen', '35')
 
     @database_only
     def test_project_network_bad_access_fails(self, db):
         """Fail to make a project-owned network that others can access."""
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
-        api.project_create('anvil-oldtimer', 'acme-corp')
+        api.project_create('anvil-nextgen')
+        api.project_create('anvil-oldtimer')
         for access in ['', 'anvil-oldtimer']:
             for net_id in ['', '35']:
                 with pytest.raises(api.BadArgumentError):
@@ -1491,8 +1410,7 @@ class TestFancyNetworkCreate:
     @database_only
     def test_admin_network(self, db):
         """Succesfully create all 4 varieties of administrator-owned networks."""
-        api.group_create('acme-corp')
-        api.project_create('anvil-nextgen', 'acme-corp')
+        api.project_create('anvil-nextgen')
         project = api._must_find(db, model.Project, 'anvil-nextgen')
         for project_api, project_db in [('', None), ('anvil-nextgen', project)]:
             for net_id, allocated in [('', True), ('35', False)]:

--- a/tests/unit/drivers/simple_vlan.py
+++ b/tests/unit/drivers/simple_vlan.py
@@ -40,7 +40,7 @@ def vlan_test(vlan_list):
             cfg.add_section('driver simple_vlan')
             cfg.set('driver simple_vlan', 'switch', '{"switch":"null"}')
             cfg.add_section('devel')
-            cfg.set('devel', 'dry_run')
+            cfg.set('devel', 'dry_run', 'True')
 
         @wraps(f)
         @clear_configuration
@@ -59,8 +59,7 @@ class TestSimpleVLAN:
 
     @vlan_test('84')
     def test_simple_vlan_network_operations(self, db):
-        api.group_create('acme-code')
-        api.project_create('anvil-nextgen', 'acme-code')
+        api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.switch_register('sw01', 'simple_vlan')
         for k in range(97,100):

--- a/tests/unit/model.py
+++ b/tests/unit/model.py
@@ -61,12 +61,6 @@ class TestUsers(ModelTest):
         return User('bob', 'secret')
 
 
-class TestGroup(ModelTest):
-
-    def sample_obj(self):
-        return Group('moc-hackers')
-
-
 class TestNic(ModelTest):
 
     def sample_obj(self):
@@ -83,7 +77,7 @@ class TestNode(ModelTest):
 class TestProject(ModelTest):
 
     def sample_obj(self):
-        return Project(Group('acme_corp'), 'manhattan')
+        return Project('manhattan')
 
 
 class TestSwitch(ModelTest):
@@ -95,18 +89,18 @@ class TestSwitch(ModelTest):
 class TestHeadnode(ModelTest):
 
     def sample_obj(self):
-        return Headnode(Project(Group('acme_corp'), 'anvil-nextgen'), 'hn-example')
+        return Headnode(Project('anvil-nextgen'), 'hn-example')
 
 
 class TestHnic(ModelTest):
 
     def sample_obj(self):
-        return Hnic(Headnode(Project(Group('acme-corp'), 'anvil-nextgen'),
+        return Hnic(Headnode(Project('anvil-nextgen'),
             'hn-0'), 'storage')
 
 
 class TestNetwork(ModelTest):
 
     def sample_obj(self):
-        pj = Project(Group('acme_corp'), 'anvil-nextgen')
+        pj = Project('anvil-nextgen')
         return Network(pj, pj, True, '102', 'hammernet')


### PR DESCRIPTION
This patch removes groups from HaaS.  Users now belong directly to projects.

Deployment and unit tests succeed accordingly.
