### PR TITLE
Generalize a comment which was VLAN-specific.

### DIFF
--- a/haas/model.py
+++ b/haas/model.py
@@ -254,8 +254,8 @@ class Network(Model):
     access    = relationship("Project",
                              backref=backref('networks_access'),
                              foreign_keys=[access_id])
-    # True if the VLAN-id came from the allocation pool; False if it was
-    # imported.
+    # True if network_id was allocated by the driver; False if it was
+    # assigned by an administrator.
     allocated = Column(Boolean)
 
     # An identifier meaningful to the networking driver:


### PR DESCRIPTION
The explanation in this comment was based around the VLAN network type.
Granted, right now we don't have any others, but this should be phrased
in a way that doesn't break abstraction boundaries. The `Network` class
should know nothing about VLANs (and it doesn't).
