### PR TITLE
Add configuration option for libvirt endpoint

### DIFF
--- a/deployment.cfg.example
+++ b/deployment.cfg.example
@@ -17,6 +17,9 @@ driver = simple_vlan
 # be bridged to to gain access to their networks.
 trunk_nic = em3
 base_imgs = base-headnode, base-headnode-2
+# libvirt instance to connect to.  This is the only value that is tested, and
+# the installation guide assumes that you are using it.
+libvirt_endpoint = qemu:///system
 
 [driver simple_vlan]
 switch = {"switch": "dell", "ip": "192.168.0.1", "user": "foo", "pass": "bar"}

--- a/haas.cfg.example
+++ b/haas.cfg.example
@@ -27,6 +27,9 @@ log_level = info
 trunk_nic = eth0
 # Base image to be selected to boot from
 base_imgs = img1, img2, img3, img4
+# libvirt instance to connect to.  This is the only value that is tested, and
+# the installation guide assumes that you are using it.
+libvirt_endpoint = qemu:///system
 
 [client]
 # The http endpoint that the client should talk to 

--- a/haas/test_common.py
+++ b/haas/test_common.py
@@ -14,6 +14,9 @@
 
 from functools import wraps
 from haas.model import *
+# XXX: This function has an underscore so that we don't import it elsewhere.
+# But... we need it here.  Oops.
+from haas.model import _on_virt_uri
 from haas.config import cfg
 from haas import api
 import json
@@ -151,7 +154,8 @@ def headnode_cleanup(f):
             # completing successfully.  For this reason, we are ignoring any
             # errors thrown by 'virsh undefine'. This should be changed once
             # we start using a version of libvirt that has fixed this bug.
-            call(['virsh', 'undefine', hn._vmname(), '--remove-all-storage'])
+            call(_on_virt_uri(['virsh', 'undefine', hn._vmname(),
+                               '--remove-all-storage']))
 
     @wraps(f)
     def wrapped(self, db):


### PR DESCRIPTION
This was needed because we really have to be using 'qemu:///system' rather
than the default on CentOS, which is 'qemu:///session'
