### PR TITLE
Improve setup.py's ability to locate requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from os import path
 
 # requirements_file is the relative path from where setup.py is being
 # called from, to where requirements.txt resides
-requirements_file = '%s/requirements.txt' % path.dirname(__file__)
+requirements_file = path.join(path.dirname(__file__), 'requirements.txt')
 requirements = [str(r.req) for r in parse_requirements(requirements_file)]
 
 setup(name='haas',


### PR DESCRIPTION
If setup.py is called from anywhere other than the directory where
it resides, it is unable to locate requirements.txt (which exists
in the same directory as setup.py).

This patch makes it so setup.py can tell where it is being called
from and use this information to locate requirements.txt.

This patch is intended to resolve issue #316.
