### PR TITLE
Use vlan_list argument in get_switch_vlans

### DIFF
--- a/haas/drivers/switches/dell.py
+++ b/haas/drivers/switches/dell.py
@@ -25,8 +25,6 @@ import re
 
 from haas.dev_support import no_dry_run
 
-from haas.drivers.driver_tools.vlan import *
-
 @no_dry_run
 def apply_networking(net_map, config):
     def set_access_vlan(port, vlan_id):
@@ -121,7 +119,7 @@ def get_switch_vlans(config, vlan_list):
     # This regex matches the notation for ports on the Dell switch.  For
     # example, 'gi1/0/24'
     regex = re.compile(r'gi\d+\/\d+\/\d+-?\d?\d?')
-    for vlan in get_vlan_list():
+    for vlan in vlan_list:
         console.sendline('show vlan tag %d' % vlan)
         console.expect(cmd_prompt)
         vlan_cfgs[vlan] = regex.findall(console.before)

--- a/haas/drivers/switches/nexus.py
+++ b/haas/drivers/switches/nexus.py
@@ -22,10 +22,7 @@ import os
 import pexpect
 import re
 
-
 from haas.dev_support import no_dry_run
-
-from haas.drivers.driver_tools.vlan import *
 
 @no_dry_run
 def apply_networking(net_map, config):


### PR DESCRIPTION
The only argument we had ever called it with was 'get_vlan_list()' anyways, but this is clearly the correct behavior, and removes an odd dependency between files.
