### PR TITLE
return 1 for invalid command

### DIFF
--- a/haas/cli.py
+++ b/haas/cli.py
@@ -587,6 +587,7 @@ def main():
     if len(sys.argv) < 2 or sys.argv[1] not in command_dict:
         # Display usage for all commands
         help()
+        sys.exit(1)
     else:
         setup_http_client()
         command_dict[sys.argv[1]](*sys.argv[2:])


### PR DESCRIPTION
In response to #583.  

I tested this by changing the 'haas_admin db create' to 'haas init_db'.  Travis failed earlier as it received the exit.