### PR TITLE
Check port

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -799,7 +799,6 @@ Authorization requirements:
 Possible errors:
 
 * 404, if no port is connected to the given nic.
-
 * 409, if the nic or port is already attached to something.
 
 ### port_detach_nic

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -333,7 +333,7 @@ Authorization requirements:
 
 `GET /node/<is_free>`
 
-Return a list of all nodes or free/available nodes. The value of `is_free` 
+Return a list of all nodes or free/available nodes. The value of `is_free`
 can be `all` to return all nodes or `free` to return free/available nodes.
 
 Response body:
@@ -798,6 +798,8 @@ Authorization requirements:
 
 Possible errors:
 
+* 404, if no port is connected to the given nic.
+
 * 409, if the nic or port is already attached to something.
 
 ### port_detach_nic
@@ -884,4 +886,3 @@ Remove a user from a project.
 Authorization requirements:
 
 * Administrative access.
-

--- a/haas/api.py
+++ b/haas/api.py
@@ -284,7 +284,7 @@ def node_connect_network(node, nic, network, channel=None):
     allocator = get_network_allocator()
 
     if nic.port is None:
-        raise NotFoundError("No port is connected to this nic.")
+        raise NotFoundError("No port is connected to given nic.")
 
     if nic.current_action:
         raise BlockedError("A networking operation is already active on the nic.")
@@ -804,14 +804,14 @@ def list_nodes(is_free):
     """List all nodes or all free nodes
 
     Returns a JSON array of strings representing a list of nodes.
-    
+
     Example:  '["node1", "node2", "node3"]'
     """
-    if is_free == "free": 
+    if is_free == "free":
         nodes = model.Node.query.filter_by(project_id=None).all()
-    else:     
+    else:
         nodes = model.Node.query.all()
-    
+
     nodes = sorted([n.label for n in nodes])
     return json.dumps(nodes)
 

--- a/haas/api.py
+++ b/haas/api.py
@@ -283,6 +283,9 @@ def node_connect_network(node, nic, network, channel=None):
 
     allocator = get_network_allocator()
 
+    if nic.port is None:
+        raise NotFoundError("No port is connected to this nic.")
+
     if nic.current_action:
         raise BlockedError("A networking operation is already active on the nic.")
 

--- a/haas/test_common.py
+++ b/haas/test_common.py
@@ -287,6 +287,35 @@ def headnode_cleanup(request):
     request.addfinalizer(undefine_headnodes)
 
 
+def additional_db():
+    """ Populated database with additional objects needed for testing.
+
+    The database setup in initial_db is required to remain static as
+    a starting point for database migrations so any changes needed for
+    testing should be made in additional_db.
+    """
+
+    initial_db()
+
+    switch = db.session.query(Switch).filter_by(label="stock_switch_0").one()
+
+    with app.app_context():
+        for node_label in ['runway_node_0', 'runway_node_1',
+                           'manhattan_node_0', 'manhattan_node_1']:
+
+            node = db.session.query(Node).filter_by(label=node_label).one()
+            nic = db.session.query(Nic).filter_by(owner=node, label='boot-nic').one()
+
+            port = Port('connected_port_0', switch)
+            port.nic = nic
+            nic.port = port
+
+            db.session.add(node)
+
+        db.session.add(switch)
+        db.session.commit()
+
+
 def initial_db():
     """Populates the database with a useful set of objects.
 

--- a/tests/unit/api/auth.py
+++ b/tests/unit/api/auth.py
@@ -18,7 +18,7 @@ from haas.auth import get_auth_backend
 from haas.errors import AuthorizationError, BadArgumentError, \
     ProjectMismatchError, BlockedError
 from haas.test_common import config_testsuite, config_merge, fresh_database, \
-    with_request_context, initial_db
+    with_request_context, additional_db
 
 from haas.ext.switches.mock import MockSwitch
 from haas.ext.obm.mock import MockObm
@@ -51,7 +51,7 @@ def auth_call_test(fn, error, admin, project, args, kwargs={}):
             fn(*args, **kwargs)
 
 
-initial_db = pytest.fixture(initial_db)
+additional_db = pytest.fixture(additional_db)
 
 
 @pytest.fixture
@@ -82,7 +82,7 @@ with_request_context = pytest.yield_fixture(with_request_context)
 
 pytestmark = pytest.mark.usefixtures('configure',
                                      'fresh_database',
-                                     'initial_db',
+                                     'additional_db',
                                      'server_init',
                                      'with_request_context')
 

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -57,6 +57,15 @@ pytestmark = pytest.mark.usefixtures('configure',
                                      'server_init',
                                      'with_request_context')
 
+@pytest.fixture
+def switchinit():
+    api.switch_register('sw0',
+                        type=MOCK_SWITCH_TYPE,
+                        username="switch_user",
+                        password="switch_pass",
+                        hostname="switchname")
+    api.switch_register_port('sw0', '3')
+
 
 class TestProjectCreateDelete:
     """Tests for the haas.api.project_* functions."""
@@ -276,14 +285,8 @@ class TestProjectConnectDetachNode:
         with pytest.raises(api.NotFoundError):
             api.project_detach_node('anvil-nextgen', 'node-99')
 
-    def test_project_detach_node_on_network(self):
+    def test_project_detach_node_on_network(self, switchinit):
         api.project_create('anvil-nextgen')
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -309,14 +312,8 @@ class TestProjectConnectDetachNode:
         network_create_simple('hammernet', 'anvil-nextgen')
         api.project_detach_node('anvil-nextgen', 'node-99')
 
-    def test_project_detach_node_removed_from_network(self):
+    def test_project_detach_node_removed_from_network(self, switchinit):
         api.project_create('anvil-nextgen')
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -513,13 +510,7 @@ class TestNodeRegisterDeleteNic:
 
 class TestNodeConnectDetachNetwork:
 
-    def test_node_connect_network_success(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_connect_network_success(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -542,13 +533,7 @@ class TestNodeConnectDetachNetwork:
         model.NetworkAttachment.query.filter_by(network=network,
                                                 nic=nic).one()
 
-    def test_node_connect_network_wrong_node_in_project(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_connect_network_wrong_node_in_project(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -644,13 +629,7 @@ class TestNodeConnectDetachNetwork:
         with pytest.raises(api.ProjectMismatchError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
-    def test_node_connect_network_different_projects(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_connect_network_different_projects(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -666,13 +645,7 @@ class TestNodeConnectDetachNetwork:
         with pytest.raises(api.ProjectMismatchError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
-    def test_node_connect_network_already_attached_to_same(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_connect_network_already_attached_to_same(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -689,13 +662,7 @@ class TestNodeConnectDetachNetwork:
         with pytest.raises(api.BlockedError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
-    def test_node_connect_network_already_attached_differently(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_connect_network_already_attached_differently(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -714,13 +681,7 @@ class TestNodeConnectDetachNetwork:
             api.node_connect_network('node-99', '99-eth0', 'hammernet2')
 
 
-    def test_node_detach_network_success(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_detach_network_success(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -757,13 +718,7 @@ class TestNodeConnectDetachNetwork:
         with pytest.raises(api.BadArgumentError):
             api.node_detach_network('node-99', '99-eth0', 'hammernet')
 
-    def test_node_detach_network_wrong_node_in_project(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_detach_network_wrong_node_in_project(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -785,13 +740,7 @@ class TestNodeConnectDetachNetwork:
         with pytest.raises(api.NotFoundError):
             api.node_detach_network('node-98', '99-eth0', 'hammernet') # changed
 
-    def test_node_detach_network_wrong_node_not_in_project(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_detach_network_wrong_node_not_in_project(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -812,13 +761,7 @@ class TestNodeConnectDetachNetwork:
         with pytest.raises(api.NotFoundError):
             api.node_detach_network('node-98', '99-eth0', 'hammernet') # changed
 
-    def test_node_detach_network_no_such_node(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_detach_network_no_such_node(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -834,13 +777,7 @@ class TestNodeConnectDetachNetwork:
         with pytest.raises(api.NotFoundError):
             api.node_detach_network('node-98', '99-eth0', 'hammernet') # changed
 
-    def test_node_detach_network_no_such_nic(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_detach_network_no_such_nic(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -856,13 +793,7 @@ class TestNodeConnectDetachNetwork:
         with pytest.raises(api.NotFoundError):
             api.node_detach_network('node-99', '99-eth1', 'hammernet') # changed
 
-    def test_node_detach_network_node_not_in_project(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_node_detach_network_node_not_in_project(self, switchinit):
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1228,15 +1159,9 @@ class TestNetworkCreateDelete:
         api.network_delete('hammernet')
         api._assert_absent(model.Network, 'hammernet')
 
-    def test_network_delete_project_complex_success(self):
+    def test_network_delete_project_complex_success(self, switchinit):
         api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1256,15 +1181,9 @@ class TestNetworkCreateDelete:
         with pytest.raises(api.NotFoundError):
             api.network_delete('hammernet')
 
-    def test_network_delete_node_on_network(self):
+    def test_network_delete_node_on_network(self, switchinit):
         api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.switch_register_port('sw0', '3')
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1362,16 +1281,16 @@ class Test_list_switches:
 
     def test_list_switches(self):
         assert json.loads(api.list_switches()) == []
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
-		username="foo", password="bar", hostname="baz")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                            username="foo", password="bar", hostname="baz")
         api._must_find(model.Switch, 'sw0')
         assert json.loads(api.list_switches()) == ['sw0']
 
-        api.switch_register('mock', type=MOCK_SWITCH_TYPE, 
-		username="user", password="password", hostname="host")
+        api.switch_register('mock', type=MOCK_SWITCH_TYPE,
+                            username="user", password="password", hostname="host")
         api._must_find(model.Switch, 'mock')
-        api.switch_register('cirius', type=MOCK_SWITCH_TYPE, 
-		username="user", password="password", hostname="switch")
+        api.switch_register('cirius', type=MOCK_SWITCH_TYPE,
+                            username="user", password="password", hostname="switch")
         api._must_find(model.Switch, 'cirius')
         assert json.loads(api.list_switches()) == [
             'cirius',
@@ -1381,10 +1300,7 @@ class Test_list_switches:
 
 class TestPortConnectDetachNic:
 
-    def test_port_connect_nic_success(self):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
-                username="switch_user", password="switch_pass", hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_port_connect_nic_success(self, switchinit):
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1434,10 +1350,7 @@ class TestPortConnectDetachNic:
         with pytest.raises(api.NotFoundError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
-    def test_port_connect_nic_already_attached_to_same(self):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
-                username="switch_user", password="switch_pass", hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_port_connect_nic_already_attached_to_same(self, switchinit):
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1448,10 +1361,7 @@ class TestPortConnectDetachNic:
         with pytest.raises(api.DuplicateError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
-    def test_port_connect_nic_nic_already_attached_differently(self):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
-                username="switch_user", password="switch_pass", hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_port_connect_nic_nic_already_attached_differently(self, switchinit):
         api.switch_register_port('sw0', '4')
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
@@ -1463,10 +1373,7 @@ class TestPortConnectDetachNic:
         with pytest.raises(api.DuplicateError):
             api.port_connect_nic('sw0', '4', 'compute-01', 'eth0')
 
-    def test_port_connect_nic_port_already_attached_differently(self):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
-                username="switch_user", password="switch_pass", hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_port_connect_nic_port_already_attached_differently(self, switchinit):
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1483,10 +1390,7 @@ class TestPortConnectDetachNic:
         with pytest.raises(api.DuplicateError):
             api.port_connect_nic('sw0', '3', 'compute-02', 'eth1')
 
-    def test_port_detach_nic_success(self):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
-                username="switch_user", password="switch_pass", hostname="switchname")
-        api.switch_register_port('sw0', '3')
+    def test_port_detach_nic_success(self, switchinit):
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1513,11 +1417,8 @@ class TestPortConnectDetachNic:
         with pytest.raises(api.NotFoundError):
             api.port_detach_nic('sw0', '3')
 
-    def port_detach_nic_node_not_free(self):
+    def port_detach_nic_node_not_free(self, switchinit):
         """should refuse to detach a nic if it has pending actions."""
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
-                username="switch_user", password="switch_pass", hostname="switchname")
-        api.switch_register_port('sw0', '3')
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -11,17 +11,16 @@
 # IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied.  See the License for the specific language
 # governing permissions and limitations under the License.
+
 """Unit tests for api.py"""
 import haas
 from haas import model, api, deferred, server, config
-# from haas.model import db
-from haas.test_common import (config_testsuite, config_merge,
-                              network_create_simple, fresh_database,
-                              with_request_context)
+from haas.model import db
+from haas.test_common import *
 from haas.network_allocator import get_network_allocator
 import pytest
 import json
-import uuid
+
 
 MOCK_SWITCH_TYPE = 'http://schema.massopencloud.org/haas/v0/switches/mock'
 OBM_TYPE_MOCK = 'http://schema.massopencloud.org/haas/v0/obm/mock'
@@ -52,8 +51,11 @@ def server_init():
 
 with_request_context = pytest.yield_fixture(with_request_context)
 
-pytestmark = pytest.mark.usefixtures('configure', 'fresh_database',
-                                     'server_init', 'with_request_context')
+
+pytestmark = pytest.mark.usefixtures('configure',
+                                     'fresh_database',
+                                     'server_init',
+                                     'with_request_context')
 
 
 class TestProjectCreateDelete:
@@ -79,14 +81,11 @@ class TestProjectCreateDelete:
             api.project_delete('anvil-nextgen')
 
     def test_project_delete_hasnode(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
@@ -94,14 +93,11 @@ class TestProjectCreateDelete:
             api.project_delete('anvil-nextgen')
 
     def test_project_delete_success_nodesdeleted(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.project_detach_node('anvil-nextgen', 'node-99')
@@ -138,41 +134,30 @@ class TestProjectCreateDelete:
 
 
 class TestNetworking:
-    def test_networking_involved(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
 
+    def test_networking_involved(self):
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         for port in '1', '2', '3':
             api.switch_register_port('sw0', port)
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
-        api.node_register(
-            'node-98',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-98', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
-        api.node_register(
-            'node-97',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+
+        api.node_register('node-97', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('node-98', 'eth0', 'DE:AD:BE:EF:20:15')
@@ -188,14 +173,11 @@ class TestNetworking:
         api.node_connect_network('node-98', 'eth0', 'hammernet')
 
     def test_networking_nic_no_port(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
 
         api.project_create('anvil-nextgen')
@@ -210,14 +192,11 @@ class TestProjectConnectDetachNode:
 
     def test_project_connect_node(self):
         api.project_create('anvil-nextgen')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         api.project_connect_node('anvil-nextgen', 'node-99')
         project = api._must_find(model.Project, 'anvil-nextgen')
@@ -227,14 +206,11 @@ class TestProjectConnectDetachNode:
 
     def test_project_connect_node_project_nexist(self):
         """Tests that connecting a node to a nonexistent project fails"""
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         with pytest.raises(api.NotFoundError):
             api.project_connect_node('anvil-nextgen', 'node-99')
 
@@ -246,14 +222,11 @@ class TestProjectConnectDetachNode:
 
     def test_project_connect_node_node_busy(self):
         """Connecting a node which is not free to a project should fail."""
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         api.project_create('anvil-oldtimer')
         api.project_create('anvil-nextgen')
@@ -264,14 +237,11 @@ class TestProjectConnectDetachNode:
 
     def test_project_detach_node(self):
         api.project_create('anvil-nextgen')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.project_detach_node('anvil-nextgen', 'node-99')
         project = api._must_find(model.Project, 'anvil-nextgen')
@@ -282,27 +252,21 @@ class TestProjectConnectDetachNode:
     def test_project_detach_node_notattached(self):
         """Tests that removing a node from a project it's not in fails."""
         api.project_create('anvil-nextgen')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         with pytest.raises(api.NotFoundError):
             api.project_detach_node('anvil-nextgen', 'node-99')
 
     def test_project_detach_node_project_nexist(self):
         """Tests that removing a node from a nonexistent project fails."""
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         with pytest.raises(api.NotFoundError):
             api.project_detach_node('anvil-nextgen', 'node-99')
 
@@ -320,14 +284,11 @@ class TestProjectConnectDetachNode:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -338,14 +299,11 @@ class TestProjectConnectDetachNode:
 
     def test_project_detach_node_success_nic_not_on_network(self):
         api.project_create('anvil-nextgen')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -359,14 +317,11 @@ class TestProjectConnectDetachNode:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -378,93 +333,73 @@ class TestProjectConnectDetachNode:
 
         api.project_detach_node('anvil-nextgen', 'node-99')
 
-
 class TestRegisterCorrectObm:
     """Tests that node_register stores obm driver information into
     correct corresponding tables
     """
 
     def test_ipmi(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         node_obj = model.Node.query.filter_by(label="compute-01")\
                         .join(model.Obm).join(haas.ext.obm.ipmi.Ipmi).first()
 
-        assert str(node_obj.label) == 'compute-01'  # Comes from table node
-        assert str(
-            node_obj.obm.api_name) == OBM_TYPE_IPMI  # Comes from table obm
-        assert str(node_obj.obm.host) == 'ipmihost'  # Comes from table ipmi
+
+        assert str(node_obj.label) == 'compute-01'              #Comes from table node
+        assert str(node_obj.obm.api_name) == OBM_TYPE_IPMI      #Comes from table obm
+        assert str(node_obj.obm.host) == 'ipmihost'             #Comes from table ipmi
+
 
     def test_mockobm(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/mock",
-                "host": "mockObmhost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/mock",
+                  "host": "mockObmhost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
-        node_obj = model.Node.query.filter_by(label="compute-01") \
-                                   .join(model.Obm).join(haas.ext.obm.mock
-                                                         .MockObm).first()
+        node_obj = model.Node.query.filter_by(label="compute-01")\
+                        .join(model.Obm).join(haas.ext.obm.mock.MockObm).first()
 
-        assert str(node_obj.label) == 'compute-01'  # Comes from table node
-        assert str(
-            node_obj.obm.api_name) == OBM_TYPE_MOCK  # Comes from table obm
-        assert str(
-            node_obj.obm.host) == 'mockObmhost'  # Comes from table mockobm
+        assert str(node_obj.label) == 'compute-01'              #Comes from table node
+        assert str(node_obj.obm.api_name) == OBM_TYPE_MOCK      #Comes from table obm
+        assert str(node_obj.obm.host) == 'mockObmhost'          #Comes from table mockobm
+
 
 
 class TestNodeRegisterDelete:
     """Tests for the haas.api.node_* functions."""
 
     def test_node_register(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api._must_find(model.Node, 'node-99')
 
     def test_duplicate_node_register(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         with pytest.raises(api.DuplicateError):
-            api.node_register(
-                'node-99',
-                obm={
-                    "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                    "host": "ipmihost",
-                    "user": "root",
-                    "password": "tapeworm"
-                })
+            api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
     def test_node_delete(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_delete('node-99')
         with pytest.raises(api.NotFoundError):
             api._must_find(model.Node, 'node-99')
@@ -475,29 +410,24 @@ class TestNodeRegisterDelete:
 
     def test_node_delete_nic_exist(self):
         """node_delete should respond with an error if the node has nics."""
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.BlockedError):
             api.node_delete('node-99')
 
 
 class TestNodeRegisterDeleteNic:
+
     def test_node_register_nic(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', '01-eth0', 'DE:AD:BE:EF:20:14')
         nic = api._must_find(model.Nic, '01-eth0')
         assert nic.owner.label == 'compute-01'
@@ -507,42 +437,33 @@ class TestNodeRegisterDeleteNic:
             api.node_register_nic('compute-01', '01-eth0', 'DE:AD:BE:EF:20:14')
 
     def test_node_register_nic_duplicate_nic(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', '01-eth0', 'DE:AD:BE:EF:20:14')
         nic = api._must_find(model.Nic, '01-eth0')
         with pytest.raises(api.DuplicateError):
             api.node_register_nic('compute-01', '01-eth0', 'DE:AD:BE:EF:20:15')
 
     def test_node_delete_nic_success(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', '01-eth0', 'DE:AD:BE:EF:20:14')
         api.node_delete_nic('compute-01', '01-eth0')
         api._assert_absent(model.Nic, '01-eth0')
         api._must_find(model.Node, 'compute-01')
 
     def test_node_delete_nic_nic_nexist(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         with pytest.raises(api.NotFoundError):
             api.node_delete_nic('compute-01', '01-eth0')
 
@@ -551,61 +472,47 @@ class TestNodeRegisterDeleteNic:
             api.node_delete_nic('compute-01', '01-eth0')
 
     def test_node_delete_nic_wrong_node(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'compute-02',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('compute-02', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', '01-eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
             api.node_delete_nic('compute-02', '01-eth0')
 
     def test_node_delete_nic_wrong_nexist_node(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', '01-eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
             api.node_delete_nic('compute-02', '01-eth0')
 
     def test_node_register_nic_diff_nodes(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'compute-02',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('compute-02', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'ipmi', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('compute-02', 'ipmi', 'DE:AD:BE:EF:20:14')
 
 
 class TestNodeConnectDetachNetwork:
+
     def test_node_connect_network_success(self):
         api.switch_register('sw0',
                             type=MOCK_SWITCH_TYPE,
@@ -613,14 +520,11 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
@@ -630,13 +534,13 @@ class TestNodeConnectDetachNetwork:
         # Check the actual HTTP response and status, not just the success;
         # we should do this at least once in the test suite, since this call
         # returns 202 instead of 200 like most things.
-        assert api.node_connect_network('node-99', '99-eth0', 'hammernet') == (
-            '', 202)
+        assert api.node_connect_network('node-99', '99-eth0', 'hammernet') == ('', 202)
         deferred.apply_networking()
 
         network = api._must_find(model.Network, 'hammernet')
         nic = api._must_find(model.Nic, '99-eth0')
-        model.NetworkAttachment.query.filter_by(network=network, nic=nic).one()
+        model.NetworkAttachment.query.filter_by(network=network,
+                                                nic=nic).one()
 
     def test_node_connect_network_wrong_node_in_project(self):
         api.switch_register('sw0',
@@ -645,87 +549,67 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
-        api.node_register(
-            'node-98',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.project_connect_node('anvil-nextgen', 'node-98')  # added
+        api.node_register('node-98', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.project_connect_node('anvil-nextgen', 'node-98') #added
 
         with pytest.raises(api.NotFoundError):
             api.node_connect_network('node-98', '99-eth0', 'hammernet')
 
     def test_node_connect_network_wrong_node_not_in_project(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.node_register(
-            'node-98',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-98', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         with pytest.raises(api.NotFoundError):
             api.node_connect_network('node-98', '99-eth0', 'hammernet')
 
     def test_node_connect_network_no_such_node(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 
         with pytest.raises(api.NotFoundError):
-            api.node_connect_network('node-98', '99-eth0',
-                                     'hammernet')  # changed
+            api.node_connect_network('node-98', '99-eth0', 'hammernet') # changed
 
     def test_node_connect_network_no_such_nic(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-
-        # api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+#        api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
@@ -734,33 +618,27 @@ class TestNodeConnectDetachNetwork:
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
     def test_node_connect_network_no_such_network(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
-        #        network_create_simple('hammernet', 'anvil-nextgen')
+#        network_create_simple('hammernet', 'anvil-nextgen')
         with pytest.raises(api.NotFoundError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
     def test_node_connect_network_node_not_in_project(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
-        #        api.project_connect_node('anvil-nextgen', 'node-99')
+#        api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 
         with pytest.raises(api.ProjectMismatchError):
@@ -773,19 +651,16 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
-        api.project_create('anvil-oldtimer')  # added
+        api.project_create('anvil-oldtimer') # added
         api.project_connect_node('anvil-nextgen', 'node-99')
-        network_create_simple('hammernet', 'anvil-oldtimer')  # changed
+        network_create_simple('hammernet', 'anvil-oldtimer') # changed
         api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
 
         with pytest.raises(api.ProjectMismatchError):
@@ -798,21 +673,18 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
-        api.node_connect_network('node-99', '99-eth0', 'hammernet')  # added
-        deferred.apply_networking()  # added
+        api.node_connect_network('node-99', '99-eth0', 'hammernet') # added
+        deferred.apply_networking() # added
 
         with pytest.raises(api.BlockedError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -824,25 +696,23 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        network_create_simple('hammernet2', 'anvil-nextgen')  # added
+        network_create_simple('hammernet2', 'anvil-nextgen') #added
         api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
-        api.node_connect_network('node-99', '99-eth0', 'hammernet')  # added
-        deferred.apply_networking()  # added
+        api.node_connect_network('node-99', '99-eth0', 'hammernet') # added
+        deferred.apply_networking() # added
 
         with pytest.raises(api.BlockedError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet2')
+
 
     def test_node_detach_network_success(self):
         api.switch_register('sw0',
@@ -851,25 +721,21 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
-        deferred.apply_networking()  # added
+        deferred.apply_networking() # added
 
         # Verify that the status is right, not just that it "succeeds."
-        assert api.node_detach_network('node-99', '99-eth0', 'hammernet') == (
-            '', 202)
+        assert api.node_detach_network('node-99', '99-eth0', 'hammernet') == ('', 202)
         deferred.apply_networking()
         network = api._must_find(model.Network, 'hammernet')
         nic = api._must_find(model.Nic, '99-eth0')
@@ -877,19 +743,16 @@ class TestNodeConnectDetachNetwork:
             .filter_by(network=network, nic=nic).count() == 0
 
     def test_node_detach_network_not_attached(self):
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        #        api.node_connect_network('node-99', '99-eth0', 'hammernet')
+#        api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.BadArgumentError):
             api.node_detach_network('node-99', '99-eth0', 'hammernet')
@@ -901,33 +764,26 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'node-98',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('node-98', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
-        api.project_connect_node('anvil-nextgen', 'node-98')  # added
+        api.project_connect_node('anvil-nextgen', 'node-98') # added
         network_create_simple('hammernet', 'anvil-nextgen')
         api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
-            api.node_detach_network('node-98', '99-eth0',
-                                    'hammernet')  # changed
+            api.node_detach_network('node-98', '99-eth0', 'hammernet') # changed
 
     def test_node_detach_network_wrong_node_not_in_project(self):
         api.switch_register('sw0',
@@ -936,22 +792,16 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'node-98',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('node-98', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
@@ -960,8 +810,7 @@ class TestNodeConnectDetachNetwork:
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
-            api.node_detach_network('node-98', '99-eth0',
-                                    'hammernet')  # changed
+            api.node_detach_network('node-98', '99-eth0', 'hammernet') # changed
 
     def test_node_detach_network_no_such_node(self):
         api.switch_register('sw0',
@@ -970,14 +819,11 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
@@ -986,8 +832,7 @@ class TestNodeConnectDetachNetwork:
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
-            api.node_detach_network('node-98', '99-eth0',
-                                    'hammernet')  # changed
+            api.node_detach_network('node-98', '99-eth0', 'hammernet') # changed
 
     def test_node_detach_network_no_such_nic(self):
         api.switch_register('sw0',
@@ -996,14 +841,11 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
@@ -1012,8 +854,7 @@ class TestNodeConnectDetachNetwork:
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
-            api.node_detach_network('node-99', '99-eth1',
-                                    'hammernet')  # changed
+            api.node_detach_network('node-99', '99-eth1', 'hammernet') # changed
 
     def test_node_detach_network_node_not_in_project(self):
         api.switch_register('sw0',
@@ -1022,25 +863,25 @@ class TestNodeConnectDetachNetwork:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', '99-eth0', 'DE:AD:BE:EF:20:14')
         api.project_create('anvil-nextgen')
-        #        api.project_connect_node('anvil-nextgen', 'node-99')
+#        api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        #        api.node_connect_network('node-99', '99-eth0', 'hammernet')
         api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+#        api.node_connect_network('node-99', '99-eth0', 'hammernet')
+
+
         with pytest.raises(api.ProjectMismatchError):
             api.node_detach_network('node-99', '99-eth0', 'hammernet')
 
 
 class TestHeadnodeCreateDelete:
+
     def test_headnode_create_success(self):
         api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
@@ -1066,6 +907,7 @@ class TestHeadnodeCreateDelete:
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
         api.headnode_create('hn-1', 'anvil-nextgen', 'base-headnode')
 
+
     def test_headnode_delete_success(self):
         api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
@@ -1079,6 +921,7 @@ class TestHeadnodeCreateDelete:
 
 
 class TestHeadnodeCreateDeleteHnic:
+
     def test_headnode_create_hnic_success(self):
         api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
@@ -1141,6 +984,7 @@ class TestHeadnodeCreateDeleteHnic:
 
 
 class TestHeadnodeConnectDetachNetwork:
+
     def test_headnode_connect_network_success(self):
         api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
@@ -1160,8 +1004,7 @@ class TestHeadnodeConnectDetachNetwork:
         network_create_simple('hammernet', 'anvil-nextgen')
 
         with pytest.raises(api.NotFoundError):
-            api.headnode_connect_network('hn-1', 'hn-0-eth0',
-                                         'hammernet')  # changed
+            api.headnode_connect_network('hn-1', 'hn-0-eth0', 'hammernet') # changed
 
     def test_headnode_connect_network_no_such_hnic(self):
         api.project_create('anvil-nextgen')
@@ -1170,8 +1013,7 @@ class TestHeadnodeConnectDetachNetwork:
         network_create_simple('hammernet', 'anvil-nextgen')
 
         with pytest.raises(api.NotFoundError):
-            api.headnode_connect_network('hn-0', 'hn-0-eth1',
-                                         'hammernet')  # changed
+            api.headnode_connect_network('hn-0', 'hn-0-eth1', 'hammernet') # changed
 
     def test_headnode_connect_network_no_such_network(self):
         api.project_create('anvil-nextgen')
@@ -1180,15 +1022,14 @@ class TestHeadnodeConnectDetachNetwork:
         network_create_simple('hammernet', 'anvil-nextgen')
 
         with pytest.raises(api.NotFoundError):
-            api.headnode_connect_network('hn-0', 'hn-0-eth0',
-                                         'hammernet2')  # changed
+            api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet2') # changed
 
     def test_headnode_connect_network_already_attached_to_same(self):
         api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet')  # added
+        api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet') # added
 
         api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet')
 
@@ -1198,17 +1039,16 @@ class TestHeadnodeConnectDetachNetwork:
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
         network_create_simple('hammernet2', 'anvil-nextgen')
-        api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet')  # added
+        api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet') # added
 
-        api.headnode_connect_network('hn-0', 'hn-0-eth0',
-                                     'hammernet2')  # changed
+        api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet2') # changed
 
     def test_headnode_connect_network_different_projects(self):
         api.project_create('anvil-nextgen')
-        api.project_create('anvil-oldtimer')  # added
+        api.project_create('anvil-oldtimer') # added
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
-        network_create_simple('hammernet', 'anvil-oldtimer')  # changed
+        network_create_simple('hammernet', 'anvil-oldtimer') #changed
 
         with pytest.raises(api.ProjectMismatchError):
             api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet')
@@ -1238,6 +1078,7 @@ class TestHeadnodeConnectDetachNetwork:
         with pytest.raises(api.BadArgumentError):
             api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet')
 
+
     def test_headnode_detach_network_success(self):
         api.project_create('anvil-nextgen')
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
@@ -1256,7 +1097,7 @@ class TestHeadnodeConnectDetachNetwork:
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
         api.headnode_create_hnic('hn-0', 'hn-0-eth0')
         network_create_simple('hammernet', 'anvil-nextgen')
-        #        api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet')
+#        api.headnode_connect_network('hn-0', 'hn-0-eth0', 'hammernet')
 
         api.headnode_detach_network('hn-0', 'hn-0-eth0')
 
@@ -1289,8 +1130,8 @@ class TestHeadnodeFreeze:
     def patch_start(self, monkeypatch):
         def start(self):
             self.dirty = False
-
         monkeypatch.setattr(model.Headnode, 'start', start)
+
 
     def _prep(self):
         """Helper to set up common state."""
@@ -1359,7 +1200,6 @@ class TestHeadnodeFreeze:
 
         api.headnode_detach_network('hn-0', 'hn-0-eth0')
 
-
 class TestNetworkCreateDelete:
     """Tests for the haas.api.network_* functions."""
 
@@ -1397,14 +1237,11 @@ class TestNetworkCreateDelete:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.port_connect_nic('sw0', '3', 'node-99', 'eth0')
@@ -1428,14 +1265,11 @@ class TestNetworkCreateDelete:
                             password="switch_pass",
                             hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.port_connect_nic('sw0', '3', 'node-99', 'eth0')
@@ -1454,57 +1288,43 @@ class TestNetworkCreateDelete:
 
 
 class Test_switch_register:
+
     def test_basic(self):
         """Calling switch_register should create an object in the db."""
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         assert model.Switch.query.one().label == 'sw0'
 
     def test_duplicate(self):
-        """switch_register should complain if asked to make a duplicate switch.
-        """
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        """switch_register should complain if asked to make a duplicate switch."""
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         with pytest.raises(api.DuplicateError):
-            api.switch_register('sw0',
-                                type=MOCK_SWITCH_TYPE,
-                                username="switch_user",
-                                password="switch_pass",
-                                hostname="switchname")
+            api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
 
 
 class Test_switch_delete:
+
     def test_basic(self):
         """Deleting a switch should actually remove it."""
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_delete('sw0')
         assert model.Switch.query.count() == 0
 
     def test_nexist(self):
-        """switch_delete should complain if asked to delete a switch that
-        doesn't exist."""
+        """switch_delete should complain if asked to delete a switch that doesn't exist."""
         with pytest.raises(api.NotFoundError):
             api.switch_delete('sw0')
 
 
 class Test_switch_register_port:
+
     def test_basic(self):
         """Creating a port on an existing switch should succeed."""
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '5')
         port = model.Port.query.one()
         assert port.label == '5'
@@ -1517,56 +1337,41 @@ class Test_switch_register_port:
 
 
 class Test_switch_delete_port:
+
     def test_basic(self):
         """Removing a port should remove it from the db."""
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '5')
         api.switch_delete_port('sw0', '5')
         assert model.Port.query.count() == 0
 
     def test_switch_nexist(self):
-        """Removing a port on a switch that does not exist should report the
-        error."""
+        """Removing a port on a switch that does not exist should report the error."""
         with pytest.raises(api.NotFoundError):
             api.switch_delete_port('sw0', '5')
 
     def test_port_nexist(self):
         """Removing a port that does not exist should report the error"""
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         with pytest.raises(api.NotFoundError):
             api.switch_delete_port('sw0', '5')
 
-
 class Test_list_switches:
+
     def test_list_switches(self):
         assert json.loads(api.list_switches()) == []
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="foo",
-                            password="bar",
-                            hostname="baz")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="foo", password="bar", hostname="baz")
         api._must_find(model.Switch, 'sw0')
         assert json.loads(api.list_switches()) == ['sw0']
 
-        api.switch_register('mock',
-                            type=MOCK_SWITCH_TYPE,
-                            username="user",
-                            password="password",
-                            hostname="host")
+        api.switch_register('mock', type=MOCK_SWITCH_TYPE, 
+		username="user", password="password", hostname="host")
         api._must_find(model.Switch, 'mock')
-        api.switch_register('cirius',
-                            type=MOCK_SWITCH_TYPE,
-                            username="user",
-                            password="password",
-                            hostname="switch")
+        api.switch_register('cirius', type=MOCK_SWITCH_TYPE, 
+		username="user", password="password", hostname="switch")
         api._must_find(model.Switch, 'cirius')
         assert json.loads(api.list_switches()) == [
             'cirius',
@@ -1574,149 +1379,104 @@ class Test_list_switches:
             'sw0',
         ]
 
-
 class TestPortConnectDetachNic:
+
     def test_port_connect_nic_success(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_switch(self):
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_port(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_node(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         with pytest.raises(api.NotFoundError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_nic(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         with pytest.raises(api.NotFoundError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_already_attached_to_same(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
         with pytest.raises(api.DuplicateError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_nic_already_attached_differently(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.switch_register_port('sw0', '4')
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
         with pytest.raises(api.DuplicateError):
             api.port_connect_nic('sw0', '4', 'compute-01', 'eth0')
 
     def test_port_connect_nic_port_already_attached_differently(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'compute-02',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('compute-02', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('compute-02', 'eth1', 'DE:AD:BE:EF:20:15')
         api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
@@ -1724,20 +1484,14 @@ class TestPortConnectDetachNic:
             api.port_connect_nic('sw0', '3', 'compute-02', 'eth1')
 
     def test_port_detach_nic_success(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
         api.port_detach_nic('sw0', '3')
@@ -1747,40 +1501,28 @@ class TestPortConnectDetachNic:
             api.port_detach_nic('sw0', '3')
 
     def test_port_detach_nic_not_attached(self):
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
             api.port_detach_nic('sw0', '3')
 
     def port_detach_nic_node_not_free(self):
         """should refuse to detach a nic if it has pending actions."""
-        api.switch_register('sw0',
-                            type=MOCK_SWITCH_TYPE,
-                            username="switch_user",
-                            password="switch_pass",
-                            hostname="switchname")
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE,
+                username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
-        api.node_register(
-            'compute-01',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
@@ -1814,30 +1556,21 @@ class TestQuery:
         assert expected == actual
 
     def test_free_nodes(self):
-        api.node_register(
-            'master-control-program',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'robocop',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'data',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('master-control-program', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('robocop', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('data', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         result = json.loads(api.list_nodes("free"))
         # For the lists to be equal, the ordering must be the same:
         result.sort()
@@ -1864,30 +1597,21 @@ class TestQuery:
 
     def test_some_non_free_nodes(self):
         """Make sure that allocated nodes don't show up in the free list."""
-        api.node_register(
-            'master-control-program',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'robocop',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'data',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('master-control-program', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('robocop', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('data', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'robocop')
@@ -1900,19 +1624,14 @@ class TestQuery:
 
         We create a node, and query it twice: once before it is reserved,
         and once after it has been reserved by a project and attached to
-        a network.
-        Two things should change:
-        (1) "project" should show registered project, and
-        (2) the newly attached network should be listed.
+        a network. Two things should change: (1) "project" should show registered project,
+        and (2) the newly attached network should be listed.
         """
-        api.node_register(
-            'robocop',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('robocop', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('robocop', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('robocop', 'wlan0', 'DE:AD:BE:EF:20:15')
 
@@ -1922,11 +1641,12 @@ class TestQuery:
             'project': None,
             'nics': [
                 {
-                    'label': 'eth0',
+                    'label':'eth0',
                     'macaddr': 'DE:AD:BE:EF:20:14',
                     "networks": {}
-                }, {
-                    'label': 'wlan0',
+                },
+                {
+                    'label':'wlan0',
                     'macaddr': 'DE:AD:BE:EF:20:15',
                     "networks": {}
                 }
@@ -1936,24 +1656,18 @@ class TestQuery:
 
     def test_show_node(self):
         """Test the show_node api call.
-
         We create a node, and query it twice: once before it is reserved,
         and once after it has been reserved by a project and attached to
-        a network.
-        Two things should change:
-        (1) "project" should show registered project, and
-        (2) the newly attached network should be listed.
+        a network. Two things should change: (1) "project" should show registered project,
+        and (2) the newly attached network should be listed.
         """
 
     def test_show_node_unavailable(self):
-        api.node_register(
-            'robocop',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('robocop', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('robocop', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('robocop', 'wlan0', 'DE:AD:BE:EF:20:15')
 
@@ -1963,11 +1677,12 @@ class TestQuery:
             'project': None,
             'nics': [
                 {
-                    'label': 'eth0',
+                    'label':'eth0',
                     'macaddr': 'DE:AD:BE:EF:20:14',
                     "networks": {}
-                }, {
-                    'label': 'wlan0',
+                },
+                {
+                    'label':'wlan0',
                     'macaddr': 'DE:AD:BE:EF:20:15',
                     "networks": {}
                 }
@@ -1983,14 +1698,11 @@ class TestQuery:
                             hostname="switchname")
         api.switch_register_port('sw0', '1')
         api.switch_register_port('sw0', '2')
-        api.node_register(
-            'robocop',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('robocop', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.node_register_nic('robocop', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('robocop', 'wlan0', 'DE:AD:BE:EF:20:15')
 
@@ -2007,7 +1719,7 @@ class TestQuery:
         actual = json.loads(api.show_node('robocop'))
         expected = {
             'name': 'robocop',
-            'project': 'anvil-nextgen',
+            'project':'anvil-nextgen',
             'nics': [
                 {
                     'label': 'eth0',
@@ -2015,12 +1727,12 @@ class TestQuery:
                     "networks": {
                         get_network_allocator().get_default_channel(): 'pxe'
                     }
-                }, {
+                },
+                {
                     'label': 'wlan0',
                     'macaddr': 'DE:AD:BE:EF:20:15',
                     "networks": {
-                        get_network_allocator().get_default_channel():
-                        'storage'
+                        get_network_allocator().get_default_channel(): 'storage'
                     }
                 }
             ],
@@ -2032,30 +1744,21 @@ class TestQuery:
             api.show_node('master-control-program')
 
     def test_project_nodes_exist(self):
-        api.node_register(
-            'master-control-program',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'robocop',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'data',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('master-control-program', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('robocop', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('data', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'master-control-program')
@@ -2095,30 +1798,21 @@ class TestQuery:
 
     def test_some_nodes_in_project(self):
         """Test that only assigned nodes are in the project."""
-        api.node_register(
-            'master-control-program',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'robocop',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
-        api.node_register(
-            'data',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('master-control-program', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('robocop', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+        api.node_register('data', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
 
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'robocop')
@@ -2138,7 +1832,11 @@ class TestQuery:
         result = json.loads(api.list_project_networks('anvil-nextgen'))
         # For the lists to be equal, the ordering must be the same:
         result.sort()
-        assert result == ['private', 'public', 'pxe']
+        assert result == [
+                'private',
+                'public',
+                'pxe'
+        ]
 
     def test_no_project_networks(self):
         api.project_create('anvil-nextgen')
@@ -2154,6 +1852,7 @@ class TestQuery:
         api.headnode_create_hnic('BGH', 'wlan0')
         api.headnode_connect_network('BGH', 'eth0', 'spiderwebs')
 
+
         result = json.loads(api.show_headnode('BGH'))
 
         # Verify UUID is well formed, then delete it, since we can't match it
@@ -2164,8 +1863,8 @@ class TestQuery:
         # For the lists to be equal, the ordering must be the same:
         result['hnics'].sort()
         assert result == {
-            'name': 'BGH',
-            'project': 'anvil-nextgen',
+            'name':     'BGH',
+            'project':  'anvil-nextgen',
             'base_img': 'base-headnode',
             'hnics': [
                 'eth0',
@@ -2178,9 +1877,10 @@ class TestQuery:
         with pytest.raises(api.NotFoundError):
             api.show_headnode('BGH')
 
+
     def test_list_headnode_images(self):
         result = json.loads(api.list_headnode_images())
-        assert result == ['base-headnode', 'img1', 'img2', 'img3', 'img4']
+        assert result == [ 'base-headnode', 'img1', 'img2', 'img3', 'img4' ]
 
 
 class Test_show_network:
@@ -2252,8 +1952,7 @@ class TestFancyNetworkCreate:
         """Fail to make a project-owned network with a supplied net-id."""
         api.project_create('anvil-nextgen')
         with pytest.raises(api.BadArgumentError):
-            api.network_create('hammernet', 'anvil-nextgen', 'anvil-nextgen',
-                               '35')
+            api.network_create('hammernet', 'anvil-nextgen', 'anvil-nextgen', '35')
 
     def test_project_network_bad_access_fails(self):
         """Fail to make a project-owned network that others can access."""
@@ -2262,16 +1961,13 @@ class TestFancyNetworkCreate:
         for access in ['', 'anvil-oldtimer']:
             for net_id in ['', '35']:
                 with pytest.raises(api.BadArgumentError):
-                    api.network_create('hammernet', 'anvil-nextgen', access,
-                                       net_id)
+                    api.network_create('hammernet', 'anvil-nextgen', access, net_id)
 
     def test_admin_network(self):
-        """Succesfully create all 4 varieties of administrator-owned networks.
-        """
+        """Succesfully create all 4 varieties of administrator-owned networks."""
         api.project_create('anvil-nextgen')
         project = api._must_find(model.Project, 'anvil-nextgen')
-        for project_api, project_db in [('', None),
-                                        ('anvil-nextgen', project)]:
+        for project_api, project_db in [('', None), ('anvil-nextgen', project)]:
             for net_id, allocated in [('', True), ('35', False)]:
                 network = 'hammernet' + project_api + net_id
                 api.network_create(network, 'admin', project_api, net_id)
@@ -2279,25 +1975,20 @@ class TestFancyNetworkCreate:
                 assert network.creator is None
                 assert network.access is project_db
                 assert network.allocated is allocated
-            network = api._must_find(model.Network,
-                                     'hammernet' + project_api + '35')
+            network = api._must_find(model.Network, 'hammernet' + project_api + '35')
             assert network.network_id == '35'
 
 
 class TestDryRun:
-    """Test that api calls using functions with @no_dry_run behave
-    reasonably."""
+    """Test that api calls using functions with @no_dry_run behave reasonably."""
 
     def test_node_power_cycle(self):
         """Check that power-cycle behaves reasonably under @no_dry_run."""
         api.project_create('anvil-nextgen')
-        api.node_register(
-            'node-99',
-            obm={
-                "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                "host": "ipmihost",
-                "user": "root",
-                "password": "tapeworm"
-            })
+        api.node_register('node-99', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.node_power_cycle('node-99')


### PR DESCRIPTION
This PR solves #474 . Basically it does a check port action before every ``node_connect_network``. This behavior is useful cause  when using HIL in real life it is hard to debug whether a port is already attached to the node's nic.

It also did ``tests/unit/api/`` adjustments since check port is not taken into consideration before.

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (tests/unit, pep8)
- [x] You've updated the documentation (if adding/changing api calls)