### PR TITLE
Specify interface for http_client

### DIFF
--- a/haas/cli.py
+++ b/haas/cli.py
@@ -478,12 +478,12 @@ def port_detach_nic(switch, port):
 @cmd
 def list_nodes(is_free):
     """List all nodes or all free nodes
-    
+
     <is_free> may be either "all" or "free", and determines whether
         to list all nodes or all free nodes.
     """
     if is_free not in ('all', 'free'):
-        raise TypeError("is_free must be either 'all' or 'free'")     
+        raise TypeError("is_free must be either 'all' or 'free'")
     url = object_url('node', is_free)
     do_get(url)
 


### PR DESCRIPTION
Apparently I glossed over a (small, but important) difference between the APIs provided by the requests library and the keystone client library. See the commit message.

//cc @henn, @gsilvis, @knikolla 