### PR TITLE
Fix list_project_networks

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -366,6 +366,24 @@ Authorization requirements:
 
 * Access to `<project>` or administrative access
 
+### list_project_networks
+
+`GET /project/<project>/networks`
+
+List all networks belonging to the given project
+
+Response body:
+
+    [
+        "network-1",
+        "network-2",
+        ...
+    ]
+
+Authorization requirements:
+
+* Access to `<project>` or administrative access
+
 ### show_node
 
 `GET /node/<node>`

--- a/haas/api.py
+++ b/haas/api.py
@@ -841,6 +841,7 @@ def list_project_networks(project):
     Example:  '["net1", "net2", "net3"]'
     """
     project = _must_find(model.Project, project)
+    get_auth_backend().require_project_access(project)
     networks = project.networks_access
     networks = sorted([n.label for n in networks])
     return json.dumps(networks)


### PR DESCRIPTION
This address the #630 . ``list_project_networks`` doesn't check auth, and the behavior is not documented in ``docs/rest_api.md``. 

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing (tests/unit, pep8)
- [x] You've updated the documentation (if adding/changing api calls)
