### PR TITLE
Fix copy/paste error where "import logging" wasn't brought over

### DIFF
--- a/haas/ext/obm/ipmi.py
+++ b/haas/ext/obm/ipmi.py
@@ -17,6 +17,7 @@
 from sqlalchemy import Column, String, Integer, ForeignKey
 import schema
 import subprocess
+import logging
 
 from haas.model import db, Obm
 from haas.errors import OBMError


### PR DESCRIPTION
This is causing an error in _ipmtool() if `status != 0`.
