### PR TITLE
Whitelist all branches in the default travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,8 @@ addons:
       - libapache2-mod-wsgi
 
 branches:
-  only:
-    - master
-    - dogfood
+  except:
+    - none
 
 env:
   - DB=sqlite


### PR DESCRIPTION
This way, folks can easily enable travis to run on their personal feature branches by going to travis-ci.com.
