### PR TITLE
Keystone: admins needn't be in the db

### DIFF
--- a/docs/keystone-auth.md
+++ b/docs/keystone-auth.md
@@ -18,7 +18,10 @@ To grant the Openstack project with that UUID access to HaaS.
 
 Note that the plugin recognizes any user with an `admin` role on any
 project as a HaaS administrator, similar to the default policy for core
-Openstack projects.
+Openstack projects. This is true even for projects not that do not exist
+within HaaS; such projects will not be able to own resources (such as
+nodes networks, etc), but may perform admin-only operations (such as
+creating projects).
 
 The HaaS command line interface will look for the same `OS_*`
 environment variables used by the Openstack command line tools; these

--- a/haas/ext/auth/keystone.py
+++ b/haas/ext/auth/keystone.py
@@ -31,6 +31,9 @@ class KeystoneAuthBackend(auth.AuthBackend):
         if request.environ['HTTP_X_IDENTITY_STATUS'] != 'Confirmed':
             return False
 
+        if self._have_admin():
+            return True
+
         project_id = request.environ['HTTP_X_PROJECT_ID']
         if Project.query.filter_by(label=project_id).count() == 0:
             logger.info("Successful authentication by Openstack project %r, "


### PR DESCRIPTION
...otherwise bootstrapping is hard.

Per our discussion on #615.

//cc @henn, @gsilvis, @knikolla 