### PR TITLE
Add VirtualHost option that includes IPv6 localhost

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -332,7 +332,7 @@ former is a WSGI application, which we recommend running with Apache's
   LoadModule wsgi_module modules/mod_wsgi.so
   WSGISocketPrefix run/wsgi
 
-  <VirtualHost 127.0.0.1:80>
+  <VirtualHost 127.0.0.1:80 [::1]:80>
     ServerName 127.0.0.1
     AllowEncodedSlashes On
     WSGIPassAuthorization On


### PR DESCRIPTION
Somebody was ssh-forwarding to a HIL server such that their local port was forwarded to the remote HIL server. The remote port was specified as "localhost:80".

What ended up happening was that the remote host interpreted `localhost` using IPv6, which caused the connections to fail using our default setup. Adding the IPv6 localhost to the default will prevent this from happening in the future.