### PR TITLE
correct headnode_create calls in docs

### DIFF
--- a/docs/INSTALL-devel.rst
+++ b/docs/INSTALL-devel.rst
@@ -294,7 +294,7 @@ Finally, ``haas help`` lists the various API commands one can use.
 Here is an example session, testing ``headnode_delete_hnic``::
 
   haas project_create proj
-  haas headnode_create hn proj
+  haas headnode_create hn proj img1
   haas headnode_create_hnic hn hn-eth0
   haas headnode_delete_hnic hn hn-eth0
 

--- a/docs/apidesc.md
+++ b/docs/apidesc.md
@@ -71,7 +71,7 @@ one exception is NICs, where the label is unique only on a per-node basis.
 
     # Headnode operations
 
-    headnode_create             <hn_label> <project_label>
+    headnode_create             <hn_label> <project_label> <base_img>
     headnode_delete             <hn_label>
 
     headnode_start              <hn_label>


### PR DESCRIPTION
Addresses #523.

Some of the docs had `haas headnode_create hn proj` but it should be `haas headnode_create hn proj img1`