### PR TITLE
Show switch

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -702,6 +702,29 @@ Authorization requirements:
 
 ## Switches
 
+
+### show_switch
+
+`GET /switch/<switch>`
+
+View detailed information about `<switch>`.
+
+The result must contain the following fields:
+
+* "name", the name of the switch
+* "ports", a list of the name of the ports which exist on the switch
+
+Response body (on success):
+
+    {
+        "name": <switch>,
+        "ports": <ports-list>
+    }
+
+Authorization requirements:
+
+* Administrative access.
+
 ### switch_register
 
 Register a network switch of type `<type>`

--- a/haas/api.py
+++ b/haas/api.py
@@ -735,23 +735,21 @@ def switch_delete_port(switch, port):
     'switch': basestring,
 }))
 def show_switch(switch):
-    switch = _must_find(model.Switch, switch)
-    attachments = {}
-    get_auth_backend().require_admin()
-    for port in switch.ports:
-        attachments[port.label] = local.db.query(model.NetworkAttachment). \
-                                filter(model.NetworkAttachment.Nic.port == port)
+    """Show details of a switch.
 
+    Returns a JSON object regrading the switch. See `docs/rest_api.md`
+    for a full description of the output.
+
+    FIXME: Ideally this api call should return all detail information about
+    this switch. right now it needs support from the switch backend.
+    """
     get_auth_backend().require_admin()
+    switch = _must_find(model.Switch, switch)
+
     return json.dumps({
-        'switch': switch.label,
-        'ports': [{'name': port.label,
-                   'attachments': [{'nic': a.nic_id,
-                                    'network': a.network_id,
-                                    'channel': a.channel,
-                                    'node': a.nic.owner,
-                   } for a in attachments[port.label]],
-        } for port in switch.ports],
+        'name': switch.label,
+        'ports': [{'label': port.label}
+                  for port in switch.ports],
     }, sort_keys=True)
 
 

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -677,11 +677,13 @@ def list_project_networks(project):
     url = object_url('project', project, 'networks')
     do_get(url)
 
+
 @cmd
 def show_switch(switch):
-    """Display information about <network>"""
+    """Display information about <switch>"""
     url = object_url('switch', switch)
     do_get(url)
+
 
 @cmd
 def show_network(network):

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -677,6 +677,11 @@ def list_project_networks(project):
     url = object_url('project', project, 'networks')
     do_get(url)
 
+@cmd
+def show_switch(switch):
+    """Display information about <network>"""
+    url = object_url('switch', switch)
+    do_get(url)
 
 @cmd
 def show_network(network):

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -1343,6 +1343,25 @@ class Test_list_switches:
         ]
 
 
+class TestShowSwitch:
+
+    def test_show_switch(self, switchinit):
+
+        assert json.loads(api.show_switch('sw0')) == {
+            'name': 'sw0',
+            'ports': [{'label': '3'}]
+        }
+
+        api.switch_register_port('sw0', 'test_port')
+        # Note: the order of ports is not sorted, test cases need to be in the
+        # same order.
+        assert json.loads(api.show_switch('sw0')) == {
+            'name': 'sw0',
+            'ports': [{'label': '3'},
+                      {'label': 'test_port'}]
+        }
+
+
 class TestPortConnectDetachNic:
 
     def test_port_connect_nic_success(self, switchinit):


### PR DESCRIPTION
This PR addresses part of the #572 's need. Per discussion with @henn and @gsilvis , right now we have `show_switch` api call, however we still need support from the switch backend. 

- [x] The commits are consistent with our contribution guidelines
- [x] You've added tests (if possible) to cover your change(s)
- [x] All tests are passing (tests/unit, pep8)
- [x] You've updated the documentation (if adding/changing api calls)

One quick question is: do we want a auth test for it? It doesn't seem like we have one for `list_switches`.