### PR TITLE
Fix Keystone gate breakage

### DIFF
--- a/ci/keystone/install.sh
+++ b/ci/keystone/install.sh
@@ -5,4 +5,4 @@ pip install python-keystoneclient
 # The exact commit we use here is somewhat arbitrary, but we want
 # something that (a) won't change out from under our feet, and (b)
 # works with our existing tests.
-keystone_commit=10.0.0.0b2 ./ci/keystone/keystone.sh setup
+keystone_commit=10.0.0.0rc3 ./ci/keystone/keystone.sh setup

--- a/ci/keystone/keystone.sh
+++ b/ci/keystone/keystone.sh
@@ -46,6 +46,10 @@ case "$1" in
     # Make sure we have the latest:
     pip install --upgrade pip
 
+    # FIXME: Workaround for https://github.com/CCI-MOC/hil/issues/675
+    # remove once https://bugs.launchpad.net/oslo.messaging/+bug/1638263 is fixed
+    pip install "kombu>=3.0.25,<4.0"
+
     pip install -r requirements.txt
     pip install .
     pip install uwsgi # To actually run keystone; no webserver in the deps.


### PR DESCRIPTION
Kombu was updated to 4.0 and oslo.messaging doesn't set an upper
bound to it resulting in package conflict versions for amqp.

Related to: #675 