### PR TITLE
Revert port

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -1009,6 +1009,21 @@ Possible errors:
 * 404, if the port is not attached to a nic
 * 409, if the port is attached to a node which is not free.
 
+#### port_revert
+
+`POST /switch/<switch>/port/<port>/revert`
+
+Detach the port from all networks.
+
+Authorization requirements:
+
+* Administrative access.
+
+Possible errors:
+
+* 404, if there is no nic attached to `port`
+* 409, if there is already a networking action pending on `port`
+
 ## API Extensions
 
 API calls provided by specific extensions. They may not exist in all

--- a/haas/api.py
+++ b/haas/api.py
@@ -1039,7 +1039,7 @@ def port_detach_nic(switch, port):
     db.session.commit()
 
 
-@rest_call('POST', '/switch/<switch>/port/<path:port>/reset', Schema({
+@rest_call('POST', '/switch/<switch>/port/<path:port>/revert', Schema({
     'switch': basestring, 'port': basestring,
 }))
 def port_revert(switch, port):

--- a/haas/api.py
+++ b/haas/api.py
@@ -1040,6 +1040,7 @@ def port_detach_nic(switch, port):
 
 
 @rest_call('POST', '/switch/<switch>/port/<path:port>/reset', Schema({
+    'switch': basestring, 'port': basestring,
 }))
 def port_revert(switch, port):
     get_auth_backend().require_admin()
@@ -1053,7 +1054,7 @@ def port_revert(switch, port):
 
     db.session.add(model.NetworkingAction(type='revert_port',
                                           nic=port.nic,
-                                          channel=None,
+                                          channel='',
                                           new_network=None))
     db.session.commit()
 

--- a/haas/api.py
+++ b/haas/api.py
@@ -401,7 +401,8 @@ def node_connect_network(node, nic, network, channel=None):
         raise BadArgumentError("Channel %r, is not legal for this network." %
                                channel)
 
-    db.session.add(model.NetworkingAction(nic=nic,
+    db.session.add(model.NetworkingAction(type='modify_port',
+                                          nic=nic,
                                           new_network=network,
                                           channel=channel))
     db.session.commit()
@@ -437,7 +438,8 @@ def node_detach_network(node, nic, network):
         .filter_by(nic=nic, network=network).first()
     if attachment is None:
         raise BadArgumentError("The network is not attached to the nic.")
-    db.session.add(model.NetworkingAction(nic=nic,
+    db.session.add(model.NetworkingAction(type='modify_port',
+                                          nic=nic,
                                           channel=attachment.channel,
                                           new_network=None))
     db.session.commit()
@@ -1034,6 +1036,25 @@ def port_detach_nic(switch, port):
         raise BlockedError("The port is attached to a node which is not free")
 
     port.nic = None
+    db.session.commit()
+
+
+@rest_call('POST', '/switch/<switch>/port/<path:port>/reset', Schema({
+}))
+def port_revert(switch, port):
+    get_auth_backend().require_admin()
+    switch = _must_find(model.Switch, switch)
+    port = _must_find_n(switch, model.Port, port)
+
+    if port.nic is None:
+        raise NotFoundError(port.label + " not attached")
+    if port.nic.current_action:
+        raise BlockedError("Port already has a pending action.")
+
+    db.session.add(model.NetworkingAction(type='revert_port',
+                                          nic=port.nic,
+                                          channel=None,
+                                          new_network=None))
     db.session.commit()
 
 

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -706,6 +706,13 @@ def port_detach_nic(switch, port):
 
 
 @cmd
+def port_revert(switch, port):
+    """Detach a <port> on a <switch> from all attached networks."""
+    url = object_url('switch', switch, 'port', port, 'revert')
+    do_post(url)
+
+
+@cmd
 def list_network_attachments(network, project):
     """List nodes connected to a network
     <project> may be either "all" or a specific project name.

--- a/haas/deferred.py
+++ b/haas/deferred.py
@@ -49,7 +49,6 @@ def apply_networking():
 
     for action in actions:
         nic = action.nic
-        network = action.new_network
         if nic.port:
             switch = nic.port.owner
             if switch.label not in switch_sessions:

--- a/haas/deferred.py
+++ b/haas/deferred.py
@@ -18,6 +18,59 @@ from haas import model
 from haas.model import db
 import logging
 
+logger = logging.getLogger(__name__)
+
+
+class DaemonSession(object):
+
+    def __init__(self):
+        self.switch_sessions = {}
+
+    def handle_action(self, action):
+        if action.type not in model.NetworkingAction.legal_types:
+            logger.warn('Illegal action type %r from server; ignoring.')
+        elif not action.nic.port:
+            logger.warn('Not modifying NIC %s; NIC is not on a port.' %
+                        action.nic.label)
+        else:
+            getattr(self, action.type)(action)
+
+    def modify_port(self, action):
+        session = self.get_session(action.nic.port.owner)
+
+        if action.new_network is None:
+            network_id = None
+        else:
+            network_id = action.new_network.network_id
+
+        session.modify_port(action.nic.port.label,
+                            action.channel,
+                            network_id)
+        if action.new_network is None:
+            model.NetworkAttachment.query \
+                .filter_by(nic=action.nic, channel=action.channel)\
+                .delete()
+        else:
+            db.session.add(model.NetworkAttachment(
+                nic=action.nic,
+                network=action.new_network,
+                channel=action.channel))
+
+    def revert_port(self, action):
+        session = self.get_session(action.nic.port.owner)
+        session.revert_port(action.nic.port.label)
+        model.NetworkAttachment.query.filter_by(nic=action.nic).delete()
+
+    def get_session(self, switch):
+        if switch.label not in self.switch_sessions:
+            self.switch_sessions[switch.label] = switch.session()
+        return self.switch_sessions[switch.label]
+
+    def close(self):
+        for session in self.switch_sessions.values():
+            session.disconnect()
+        self.switch_sessions = {}
+
 
 def apply_networking():
     """Do each networking action in the journal, then cross them off.
@@ -40,40 +93,15 @@ def apply_networking():
     actions = model.NetworkingAction.query \
         .order_by(model.NetworkingAction.id).all()
 
-    switch_sessions = {}
-
     if actions == []:
         # No actions to perform.  Return False immediately.
         db.session.commit()
         return False
 
+    session = DaemonSession()
     for action in actions:
-        nic = action.nic
-        if nic.port:
-            switch = nic.port.owner
-            if switch.label not in switch_sessions:
-                switch_sessions[switch.label] = switch.session()
-            switch_sessions[switch.label].apply_networking(action)
-        else:
-            logging.getLogger(__name__).warn(
-                'Not modifying NIC %s; NIC is not on a port.' %
-                nic.label)
-
-    # Close all of our sessions:
-    for session in switch_sessions.values():
-        session.disconnect()
-
-    # Then perform the database changes and delete them
-    for action in actions:
-        if action.new_network is None:
-            model.NetworkAttachment.query \
-                .filter_by(nic=action.nic, channel=action.channel)\
-                .delete()
-        else:
-            db.session.add(model.NetworkAttachment(nic=action.nic,
-                                                   network=action.new_network,
-                                                   channel=action.channel))
-        db.session.delete(action)
-
+        session.handle_action(action)
+    session.close()
+    model.NetworkingAction.query.delete()
     db.session.commit()
     return True

--- a/haas/ext/switches/_console.py
+++ b/haas/ext/switches/_console.py
@@ -84,11 +84,14 @@ class Session(object):
         if channel == 'vlan/native':
             old_native = NetworkAttachment.query.filter_by(
                 channel='vlan/native',
-                nic_id=port.nic.id).one().network.network_id
-            if network_id is None:
-                self.disable_native(old_native)
-            else:
+                nic_id=port.nic.id).first()
+            if old_native is not None:
+                old_native = old_native.network.network_id
+
+            if network_id is not None:
                 self.set_native(old_native, network_id)
+            elif old_native is not None:
+                self.disable_native(old_native)
         else:
             match = re.match(_CHANNEL_RE, channel)
             # TODO: I'd be more okay with this assertion if it weren't possible

--- a/haas/ext/switches/_console.py
+++ b/haas/ext/switches/_console.py
@@ -14,6 +14,7 @@
 """Common functionality for switches with a cisco-like console."""
 
 from abc import ABCMeta, abstractmethod
+from haas.model import Port, NetworkAttachment
 import re
 
 
@@ -65,26 +66,29 @@ class Session(object):
         """
 
     @abstractmethod
+    def disable_port(self):
+        """Disable all vlans on the current port."""
+
+    @abstractmethod
     def disconnect(self):
         """End the session. Must be at the main prompt."""
 
-    def apply_networking(self, action):
-        interface = action.nic.port.label
-        channel = action.channel
+    def modify_port(self, port, channel, network_id):
+        interface = port
+        port = Port.query.filter_by(label=port,
+                                    owner_id=self.switch.id).one()
 
         self.enter_if_prompt(interface)
         self.console.expect(self.if_prompt)
 
         if channel == 'vlan/native':
-            old_native = None
-            old_attachments = filter(lambda a: a.channel == 'vlan/native',
-                                     action.nic.attachments)
-            if len(old_attachments) != 0:
-                old_native = old_attachments[0].network.network_id
-            if action.new_network is None:
+            old_native = NetworkAttachment.query.filter_by(
+                channel='vlan/native',
+                nic_id=port.nic.id).one().network.network_id
+            if network_id is None:
                 self.disable_native(old_native)
             else:
-                self.set_native(old_native, action.new_network.network_id)
+                self.set_native(old_native, network_id)
         else:
             match = re.match(_CHANNEL_RE, channel)
             # TODO: I'd be more okay with this assertion if it weren't possible
@@ -94,11 +98,20 @@ class Session(object):
             assert match is not None, "HaaS passed an invalid channel to the" \
                 "switch!"
             vlan_id = match.groups()[0]
-            if action.new_network is None:
+            if network_id is None:
                 self.disable_vlan(vlan_id)
             else:
-                assert action.new_network.network_id == vlan_id
+                assert network_id == vlan_id
                 self.enable_vlan(vlan_id)
+
+        self.exit_if_prompt()
+        self.console.expect(self.config_prompt)
+
+    def revert_port(self, port):
+        self.enter_if_prompt(port)
+        self.console.expect(self.if_prompt)
+
+        self.disable_port()
 
         self.exit_if_prompt()
         self.console.expect(self.config_prompt)

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -92,7 +92,7 @@ class Brocade(Switch):
                 self._add_vlan_to_trunk(interface, vlan_id)
 
     def revert_port(self, port):
-        self._remove_all_vlans_from_trunk(port, vlan)
+        self._remove_all_vlans_from_trunk(port)
         self._remove_native_vlan(port)
 
     def get_port_networks(self, ports):
@@ -223,9 +223,9 @@ class Brocade(Switch):
         payload = '<vlan><remove>%s</remove></vlan>' % vlan
         self._make_request('PUT', url, data=payload)
 
-    def _remove_all_vlans_from_trunk(self, interface, vlan):
+    def _remove_all_vlans_from_trunk(self, interface):
         url = self._construct_url(interface, suffix='trunk/allowed/vlan')
-        payload = '<vlan><none>true</none></vlan>' % vlan
+        payload = '<vlan><none>true</none></vlan>'
         requests.put(url, data=payload, auth=self._auth)
 
     def _set_native_vlan(self, interface, vlan):

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -61,11 +61,6 @@ class Brocade(Switch):
         pass
 
     def modify_port(self, port, channel, network_id):
-        """ Apply a NetworkingAction to the switch.
-
-        Args:
-            action: NetworkingAction to apply to the switch.
-        """
         # XXX: We ought to be able to do a Port.query ... one() here, but
         # there's somthing I(zenhack)  don't understand going on with when
         # things are committed in the tests for this driver, and we don't
@@ -224,6 +219,11 @@ class Brocade(Switch):
         self._make_request('PUT', url, data=payload)
 
     def _remove_all_vlans_from_trunk(self, interface):
+        """ Remove all vlan from a trunk port.
+
+        Args:
+            interface: interface to remove the vlan from
+        """
         url = self._construct_url(interface, suffix='trunk/allowed/vlan')
         payload = '<vlan><none>true</none></vlan>'
         requests.put(url, data=payload, auth=self._auth)

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -95,10 +95,10 @@ class Brocade(Switch):
         # TODO: there is likely a more efficient way to do this; we may want
         # to inspect the brocade documentation to see if there's a way to
         # clear the port without doing every vlan individually.
-        vlans = self._get_vlans()
+        vlans = self._get_vlans(port)
         for _, vlan in vlans:
-            self._remove_vlan_from_trunk()
-        self._remove_native_vlan()
+            self._remove_vlan_from_trunk(port, vlan)
+        self._remove_native_vlan(port)
 
     def get_port_networks(self, ports):
         """Get port configurations of the switch.

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -91,7 +91,7 @@ class Brocade(Switch):
                 assert network_id == vlan_id
                 self._add_vlan_to_trunk(interface, vlan_id)
 
-    def port_revert(self, port):
+    def revert_port(self, port):
         # TODO: there is likely a more efficient way to do this; we may want
         # to inspect the brocade documentation to see if there's a way to
         # clear the port without doing every vlan individually.

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -88,7 +88,8 @@ class Brocade(Switch):
 
     def revert_port(self, port):
         self._remove_all_vlans_from_trunk(port)
-        self._remove_native_vlan(port)
+        if self._get_native_vlan(port) is not None:
+            self._remove_native_vlan(port)
 
     def get_port_networks(self, ports):
         """Get port configurations of the switch.

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -92,12 +92,7 @@ class Brocade(Switch):
                 self._add_vlan_to_trunk(interface, vlan_id)
 
     def revert_port(self, port):
-        # TODO: there is likely a more efficient way to do this; we may want
-        # to inspect the brocade documentation to see if there's a way to
-        # clear the port without doing every vlan individually.
-        vlans = self._get_vlans(port)
-        for _, vlan in vlans:
-            self._remove_vlan_from_trunk(port, vlan)
+        self._remove_all_vlans_from_trunk(port, vlan)
         self._remove_native_vlan(port)
 
     def get_port_networks(self, ports):
@@ -227,6 +222,11 @@ class Brocade(Switch):
         url = self._construct_url(interface, suffix='trunk/allowed/vlan')
         payload = '<vlan><remove>%s</remove></vlan>' % vlan
         self._make_request('PUT', url, data=payload)
+
+    def _remove_all_vlans_from_trunk(self, interface, vlan):
+        url = self._construct_url(interface, suffix='trunk/allowed/vlan')
+        payload = '<vlan><none>true</none></vlan>' % vlan
+        requests.put(url, data=payload, auth=self._auth)
 
     def _set_native_vlan(self, interface, vlan):
         """ Set the native vlan of an interface.

--- a/haas/ext/switches/dell.py
+++ b/haas/ext/switches/dell.py
@@ -157,7 +157,8 @@ class _Session(_console.Session):
         return result
 
     def disable_port(self):
-        assert False, "Unimplemented"
+        self._sendline('sw trunk allowed vlan none')
+        self._sendline('sw trunk native vlan none')
 
     def _port_configs(self, ports):
         result = {}

--- a/haas/ext/switches/dell.py
+++ b/haas/ext/switches/dell.py
@@ -156,6 +156,9 @@ class _Session(_console.Session):
             result[k] = networks
         return result
 
+    def disable_port(self):
+        assert False, "Unimplemented"
+
     def _port_configs(self, ports):
         result = {}
         for port in ports:

--- a/haas/ext/switches/mock.py
+++ b/haas/ext/switches/mock.py
@@ -59,14 +59,16 @@ class MockSwitch(Switch):
     def session(self):
         return self
 
-    def apply_networking(self, action):
+    def modify_port(self, port, channel, network_id):
         state = LOCAL_STATE[self.label]
-        port = action.nic.port.label
 
-        if action.new_network is None:
-            del state[port][action.channel]
+        if network_id is None:
+            del state[port][channel]
         else:
-            state[port][action.channel] = action.new_network.network_id
+            state[port][channel] = network_id
+
+    def revert_port(self, port):
+        del LOCAL_STATE[self.label][port]
 
     def disconnect(self):
         pass

--- a/haas/ext/switches/nexus.py
+++ b/haas/ext/switches/nexus.py
@@ -204,4 +204,5 @@ class _Session(_console.Session):
         return result
 
     def disable_port(self):
-        assert False, "unimplemented"
+        self.console.sendline('sw trunk allowed vlan none')
+        self.console.sendline('sw trunk native vlan ' + self.dummy_vlan)

--- a/haas/ext/switches/nexus.py
+++ b/haas/ext/switches/nexus.py
@@ -202,3 +202,6 @@ class _Session(_console.Session):
                 networks.append(('vlan/native', native))
             result[k] = networks
         return result
+
+    def disable_port(self):
+        assert False, "unimplemented"

--- a/haas/migrations/versions/3b2dab2e0d7d_add_type_field_to_networkingaction.py
+++ b/haas/migrations/versions/3b2dab2e0d7d_add_type_field_to_networkingaction.py
@@ -1,0 +1,26 @@
+"""Add type field to NetworkingAction
+
+Revision ID: 3b2dab2e0d7d
+Revises: 89630e3872ec
+Create Date: 2016-11-14 14:57:19.247255
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3b2dab2e0d7d'
+down_revision = '57f4c30b0ad4'
+branch_labels = ('haas',)
+
+
+def upgrade():
+    op.add_column('networking_action',
+                  sa.Column('type', sa.String(),
+                            nullable=False))
+
+
+def downgrade():
+    op.drop_column('networking_action', 'type')

--- a/haas/migrations/versions/57f4c30b0ad4_added_metadata.py
+++ b/haas/migrations/versions/57f4c30b0ad4_added_metadata.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 # revision identifiers, used by Alembic.
 revision = '57f4c30b0ad4'
 down_revision = '89630e3872ec'
-branch_labels = ('haas',)
+branch_labels = None
 
 
 def upgrade():

--- a/tests/deployment/native_networks.py
+++ b/tests/deployment/native_networks.py
@@ -110,13 +110,19 @@ class TestNativeNetwork(NetworkTest):
             nodes = project.nodes
             ports = self.get_all_ports(nodes)
 
-            # Remove all nodes from their networks
-            for node in nodes:
+            # Remove all nodes from their networks. We do this in two different
+            # ways for different ports to test the different mechanisms. For
+            # the first two nodes we explicity remove the attachments. For the
+            # latter two we call port_revert.
+            for node in nodes[:2]:
                 attachment = model.NetworkAttachment.query \
                     .filter_by(nic=node.nics[0]).one()
                 api.node_detach_network(node.label,
                                         node.nics[0].label,
                                         attachment.network.label)
+            for node in nodes[2:]:
+                port = node.nics[0].port
+                api.port_revert(port.owner.label, port.label)
             deferred.apply_networking()
 
             # Assert that none of the nodes are on any network

--- a/tests/unit/api/auth.py
+++ b/tests/unit/api/auth.py
@@ -644,6 +644,7 @@ admin_calls = [
     (api.port_detach_nic, ['stock_switch_0', 'free_node_0_port'], {}),
     (api.node_set_metadata, ['free_node_0', 'EK', 'pk'], {}),
     (api.node_delete_metadata, ['runway_node_0', 'EK'], {}),
+    (api.port_revert, ['stock_switch_0', 'free_node_0_port'], {}),
 ]
 
 

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -226,6 +226,60 @@ class TestNetworking:
             api.node_connect_network('node-99', 'eth0', 'hammernet')
 
 
+class Test_port_revert:
+
+    def test_no_nic(self):
+        from haas.ext.switches.mock import LOCAL_STATE
+        initial_db()
+
+        assert LOCAL_STATE['stock_switch_0']['free_port_0'] == {}
+        with pytest.raises(api.NotFoundError):
+            # free_port_0 is not attached to a nic.
+            api.port_revert('stock_switch_0', 'free_port_0')
+        deferred.apply_networking()
+        assert LOCAL_STATE['stock_switch_0']['free_port_0'] == {}
+
+    def test_one_network(self):
+        from haas.ext.switches.mock import LOCAL_STATE
+        initial_db()
+
+        assert LOCAL_STATE['stock_switch_0']['runway_node_0_port'] == {}
+        api.node_connect_network('runway_node_0',
+                                 'nic-with-port',
+                                 'runway_pxe',
+                                 'null')
+        deferred.apply_networking()
+
+        net_id = model.Network.query.filter_by(label='runway_pxe')\
+            .one().network_id
+        assert LOCAL_STATE['stock_switch_0']['runway_node_0_port'] == {
+            'null': net_id,
+        }
+
+        api.port_revert('stock_switch_0', 'runway_node_0_port')
+        deferred.apply_networking()
+
+        assert LOCAL_STATE['stock_switch_0']['runway_node_0_port'] == {}, (
+            "port_revert did not detach the port from the networks!"
+        )
+
+        network = model.Network.query.filter_by(label='runway_pxe').one()
+        assert model.NetworkAttachment.query.filter_by(
+            network_id=network.id,
+        ).first() is None, (
+            "port_revert did not remove the network attachment object in "
+            "the database!"
+        )
+
+    def test_two_networks(self):
+        assert False, (
+            "TODO: We need to test port_revert with more than one network "
+            "attached to the port, but this needs a bit of tweaking since "
+            "right now the null network allocator doesn't allow more than "
+            "one channel. "
+        )
+
+
 class TestProjectConnectDetachNode:
 
     def test_project_connect_node(self):

--- a/tests/unit/api/port_revert.py
+++ b/tests/unit/api/port_revert.py
@@ -1,0 +1,104 @@
+import unittest
+import pytest
+from haas.test_common import \
+    config_testsuite, config_merge, fail_on_log_warnings, \
+    initial_db, newDB, releaseDB
+from haas import api, config, deferred, model
+from haas.flaskapp import app
+
+
+class Test_port_revert(unittest.TestCase):
+
+    def setUp(self):
+        from haas.ext.switches.mock import LOCAL_STATE
+        self.LOCAL_STATE = LOCAL_STATE
+        fail_on_log_warnings()
+
+        # Configure HaaS:
+        config_testsuite()
+        config_merge({
+            'extensions': {
+                'haas.ext.switches.mock': '',
+                'haas.ext.obm.ipmi': '',
+                'haas.ext.obm.mock': '',
+                'haas.ext.network_allocators.null': None,
+                'haas.ext.network_allocators.vlan_pool': '',
+            },
+            'haas.ext.network_allocators.vlan_pool': {
+                'vlans': '100-200',
+            },
+        })
+        config.load_extensions()
+
+        newDB()  # Initialize the db schema
+        initial_db()  # Populate the db with objects
+
+        # Sanity check the start state:
+        assert self.LOCAL_STATE['stock_switch_0']['free_port_0'] == {}
+
+        self.request_context = app.test_request_context()
+        self.request_context.push()
+
+    def tearDown(self):
+        self.request_context.pop()
+        releaseDB()
+
+    def test_no_nic(self):
+        with pytest.raises(api.NotFoundError):
+            # free_port_0 is not attached to a nic.
+            api.port_revert('stock_switch_0', 'free_port_0')
+        deferred.apply_networking()
+        assert self.LOCAL_STATE['stock_switch_0']['free_port_0'] == {}
+
+    def test_one_network(self):
+        api.node_connect_network('runway_node_0',
+                                 'nic-with-port',
+                                 'runway_pxe',
+                                 'vlan/native')
+        deferred.apply_networking()
+
+        net_id = model.Network.query.filter_by(label='runway_pxe')\
+            .one().network_id
+        assert self.LOCAL_STATE['stock_switch_0']['runway_node_0_port'] == {
+            'vlan/native': net_id,
+        }
+
+        api.port_revert('stock_switch_0', 'runway_node_0_port')
+        deferred.apply_networking()
+
+        assert self.LOCAL_STATE['stock_switch_0']['runway_node_0_port'] == {},\
+            "port_revert did not detach the port from the networks!"
+
+        network = model.Network.query.filter_by(label='runway_pxe').one()
+        assert model.NetworkAttachment.query.filter_by(
+            network_id=network.id,
+        ).first() is None, (
+            "port_revert did not remove the network attachment object in "
+            "the database!"
+        )
+
+    def test_two_networks(self):
+        pxe_net_id = model.Network.query.filter_by(label='runway_pxe')\
+            .one().network_id
+        pub_net_id = model.Network.query.filter_by(label='stock_int_pub')\
+            .one().network_id
+        api.node_connect_network('runway_node_0',
+                                 'nic-with-port',
+                                 'runway_pxe',
+                                 'vlan/native')
+        deferred.apply_networking()
+        assert self.LOCAL_STATE['stock_switch_0']['runway_node_0_port'] == {
+            'vlan/native': pxe_net_id,
+        }
+        api.node_connect_network('runway_node_0',
+                                 'nic-with-port',
+                                 'stock_int_pub',
+                                 'vlan/' + pub_net_id)
+        deferred.apply_networking()
+        assert self.LOCAL_STATE['stock_switch_0']['runway_node_0_port'] == {
+            'vlan/native': pxe_net_id,
+            'vlan/' + pub_net_id: pub_net_id,
+        }
+        api.port_revert('stock_switch_0', 'runway_node_0_port')
+        deferred.apply_networking()
+        assert self.LOCAL_STATE['stock_switch_0']['runway_node_0_port'] == {}

--- a/tests/unit/migrations.py
+++ b/tests/unit/migrations.py
@@ -154,7 +154,7 @@ def get_db_state():
         inspector.reflecttable(tbl, None)
         rows = db.session.query(tbl).all()
         result[name] = {
-            'schema': schema,
+            'schema': sorted(schema),
             'rows': sorted(rows),
         }
 


### PR DESCRIPTION
WIP; the commit messages give a good summary of what's done so far. Feel free to dig in to what's there; modulo comments I don't have plans to change the design dramatically.

(Edit: added a checklist)

* [x] Modify api server -> networking daemon interface to accommodate this
* [x] Make changes needed in the networking daemon.
* [x] Database migration script for the change to NetworkingAction
* [x] Expose the API call via HTTP
* [x] Add CLI wrapper for the call
* [x] Make the necessary changes to other switch drivers
* [x] Write new tests; the above passes existing tests, but these don't
      exercise the revert_port paths.
  * [x] Write unit tests that work agains the mock switch driver.
  * [x] Integrate into the deployment tests for real switches.