### PR TITLE
Migration tests: parametrize fresh_create.

### DIFF
--- a/tests/unit/migrations.py
+++ b/tests/unit/migrations.py
@@ -144,7 +144,24 @@ def get_db_state():
     }],
 ])
 def test_db_eq(filename, make_objects, extra_config):
-    """Verify that each function in fns creates the same database."""
+    """Migrating from a snapshot should create the same objects as a new db.
+
+    `make_objects` is a function that, when run against the latest version
+        of a schema, will create some set of objects.
+    `filename` is the name of an sql dump of a previous database, whose
+        contents were created with the then-current version of `make_objects`.
+    `extra_config` specifies modifications to the haas.cfg under which the
+        test is run. this is passed to `config_merge`.
+
+    The test does the following:
+
+        * Restore the database snapshot and run the migration scripts to update
+          its contents to the current schema.
+        * Create a fresh database according to the current schema, and execute
+          `make_objects`.
+        * Compare the two resulting databases. The test passes if and only if
+          they are the same.
+    """
 
     config_merge(extra_config)
     load_extensions()

--- a/tests/unit/migrations.py
+++ b/tests/unit/migrations.py
@@ -87,14 +87,14 @@ def load_dump(filename):
     upgrade(revision='heads')
 
 
-def fresh_create():
+def fresh_create(make_objects):
     """Create a fresh database, and populate it with an initial set of objects.
 
-    The objects are created via `initial_db`. These objects should be such that
-    a migrated database dump will have the same contents.
+    The objects are created via `make_objects`. These objects should be such
+    that a migrated database dump will have the same contents.
     """
     create_db()
-    initial_db()
+    make_objects()
 
 
 def get_db_state():
@@ -123,8 +123,8 @@ def get_db_state():
     return result
 
 
-@pytest.mark.parametrize('filename,extra_config', [
-    ['flask.sql', {
+@pytest.mark.parametrize('filename,make_objects,extra_config', [
+    ['flask.sql', initial_db, {
         'extensions': {
             'haas.ext.switches.mock': '',
             'haas.ext.switches.nexus': '',
@@ -143,7 +143,7 @@ def get_db_state():
         },
     }],
 ])
-def test_db_eq(filename, extra_config):
+def test_db_eq(filename, make_objects, extra_config):
     """Verify that each function in fns creates the same database."""
 
     config_merge(extra_config)
@@ -164,7 +164,7 @@ def test_db_eq(filename, extra_config):
         return get_db_state()
 
     upgraded = run_fn(lambda: load_dump(filename))
-    fresh = run_fn(fresh_create)
+    fresh = run_fn(lambda: fresh_create(make_objects))
     drop_tables()
 
     def censor_nondeterminism(string):


### PR DESCRIPTION
This will allow us to write migration tests that look at specific scenarios; right now we call initial_db to create the objects, which means the database we have to migrate from is fixed for all tests.

In particular, I want to shove some `NetworkingAction`s in the DB as part of testing #683, without a whole lot else to complicate things.