### PR TITLE
Deployment test doc fixes

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -126,6 +126,9 @@ and has three fields:
   `"pass"`, defining the information needed to talk to the IPMI
   controller of the node.
 
+The tests currently require at least four nodes to be specified in
+`site-layout.json`, each of which must have at least one nic connected
+to the switch.
 
 [1]: http://pytest.org/
 [2]: https://pypi.python.org/pypi/pytest-cov

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -94,11 +94,12 @@ relating to specific hardware support, or interacting with headnodes. To
 run the deployment tests, you must do the following:
 
 * Write a `testsuite.cfg` reflecting your environment. Copy
-  `testsuite.cfg.default` and edit. In particular, you will need to load
-  the extensions for your switch drivers and the corresponding network
-  allocator (see `drivers.md`), and specify extension-specific options.
+  `examples/testsuite.cfg-deployment` and edit. In particular, you will
+  need to load the extensions for your switch drivers and the
+  corresponding network allocator (see `drivers.md`), and specify
+  extension-specific options.
 * Write a `site-layout.json` describing the layout of your environment.
-  The file `site-layout.json.example` provides an example. Here is a
+  The file `examples/site-layout.json` provides an example. Here is a
   full description of the file format:
 
 `site-layout.json` must contain a single json object, with two fields:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -122,9 +122,8 @@ and has three fields:
   * `"switch"`, the name of the switch that the nic is connected to
   * `"port"`, the name/label of the port on the switch that the nic is
     connected to
-* `"ipmi"`, an object with the string fields `"host"`, `"user"`,
-  `"pass"`, defining the information needed to talk to the IPMI
-  controller of the node.
+* `"obm"`, An object with the same set of fields as required by the obm
+  field in the `node_register` API call.
 
 The tests currently require at least four nodes to be specified in
 `site-layout.json`, each of which must have at least one nic connected

--- a/examples/testsuite.cfg-deployment
+++ b/examples/testsuite.cfg-deployment
@@ -1,7 +1,7 @@
 # This is an example testsuite.cfg for running the deployment tests (in
-# ``tests/deployment``). ``site-layout.json`` it is designed to accompany
-# ``site-layout.json`` in this directory. You will most likely have to modify
-# both files according to your local environment.
+# ``tests/deployment``). it is designed to accompany
+# ``site-layout.json`` in this directory. You will most likely have to
+# modify both files according to your local environment.
 [general]
 log_level = debug
 


### PR DESCRIPTION
@naved001 is working on getting a test/dev environment set up for me to use when making changes to the brocade driver re: #683. He asked about required number of nodes, and I went to find the documentation which I was sure existed re: what was needed to run the deployment tests, only to find that it wasn't documented (except in the source). This patch fixes that, and a couple of other issues I noticed in the process.

//cc @henn, @knikolla, @shwsun 