### PR TITLE
Fix bogus i18n call.

### DIFF
--- a/haas/network_allocator.py
+++ b/haas/network_allocator.py
@@ -93,8 +93,8 @@ def set_network_allocator(network_allocator):
     """
     global _network_allocator
     if _network_allocator is not None:
-        sys.exit(_("Fatal Error: set_network_allocator() called twice."
-                   "Make sure you don't have conflicting extensions loaded."))
+        sys.exit("Fatal Error: set_network_allocator() called twice."
+                 "Make sure you don't have conflicting extensions loaded.")
 
     _network_allocator = network_allocator
 


### PR DESCRIPTION
The `_` function is a common alias used when doing internationalization.
We don't actually do i18n yet, and there's no alias defined/imported in
this file, so if this statement gets executed, it raises a NameError.

This was introduced in commit 16016078453913918dcec208c2c000a7f935a488,
though it's not clear to me why.

@matsuuran, that commit has your name on it; any idea what happened there?

@shwsun, @knikolla, @henn, reviews appreciated.