### PR TITLE
Fix #697

### DIFF
--- a/tests/unit/api/auth.py
+++ b/tests/unit/api/auth.py
@@ -20,8 +20,8 @@ from haas.errors import AuthorizationError, BadArgumentError, \
 from haas.test_common import config_testsuite, config_merge, fresh_database, \
     with_request_context, additional_db, fail_on_log_warnings
 
-from haas.ext.switches.mock import MockSwitch
-from haas.ext.obm.mock import MockObm
+MOCK_OBM_API_NAME = 'http://schema.massopencloud.org/haas/v0/obm/mock'
+MOCK_SWITCH_API_NAME = 'http://schema.massopencloud.org/haas/v0/switches/mock'
 
 
 def auth_call_test(fn, error, admin, project, args, kwargs={}):
@@ -611,7 +611,7 @@ def test_auth_call(kwargs):
 
 admin_calls = [
     (api.node_register, ['new_node'], {'obm': {
-              "type": MockObm.api_name,
+              "type": MOCK_OBM_API_NAME,
               "host": "ipmihost",
               "user": "root",
               "password": "tapeworm"}}),
@@ -630,7 +630,7 @@ admin_calls = [
 
     (api.project_delete, ['empty-project'], {}),
 
-    (api.switch_register, ['new-switch', MockSwitch.api_name], {
+    (api.switch_register, ['new-switch', MOCK_SWITCH_API_NAME], {
         'hostname': 'oak-ridge',
         'username': 'alice',
         'password': 'changeme',

--- a/tests/unit/class_resolver.py
+++ b/tests/unit/class_resolver.py
@@ -1,13 +1,17 @@
 import haas
 from haas.class_resolver import *
 from haas.model import *
-from haas.ext.obm import mock
-from haas.ext.switches import mock
 from haas.test_common import fail_on_log_warnings
 import pytest
 
 mockapi_name = 'http://schema.massopencloud.org/haas/v0/'
 fail_on_log_warnings = pytest.fixture(autouse=True)(fail_on_log_warnings)
+
+
+@pytest.fixture(autouse=True)
+def mock_extensions():
+    from haas.ext.obm import mock
+    from haas.ext.switches import mock
 
 
 class Food(object):

--- a/tests/unit/ext/network_allocators/vlan_pool.py
+++ b/tests/unit/ext/network_allocators/vlan_pool.py
@@ -2,7 +2,6 @@ from haas.config import load_extensions
 from haas.flaskapp import app
 from haas.model import db
 from haas.migrations import create_db
-from haas.ext.network_allocators.vlan_pool import Vlan
 from haas import api, model, server
 from haas.test_common import *
 import pytest
@@ -52,6 +51,7 @@ def test_populate_dirty_db():
     """
     # The fresh_database fixture will have created a clean database for us. We
     # just tweak it and then re-run create_db
+    from haas.ext.network_allocators.vlan_pool import Vlan
     with app.app_context():
         # flag vlan 100 as in-use, just so the db isn't quite pristine.
         vlan100 = Vlan.query.filter_by(vlan_no=100)

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -15,9 +15,7 @@
 import pytest
 import requests_mock
 
-from haas.ext.switches import brocade
 from haas import model
-from haas.ext.obm.ipmi import Ipmi
 from haas.test_common import fail_on_log_warnings
 
 fail_on_log_warnings = pytest.fixture(autouse=True)(fail_on_log_warnings)
@@ -138,6 +136,7 @@ class TestBrocade(object):
     """
     @pytest.fixture()
     def switch(self):
+        from haas.ext.switches import brocade
         return brocade.Brocade(
             hostname='http://example.com',
             username='admin',
@@ -147,6 +146,7 @@ class TestBrocade(object):
 
     @pytest.fixture()
     def nic(self):
+        from haas.ext.obm.ipmi import Ipmi
         return model.Nic(
             model.Node(
                 label='node-99',

--- a/tests/unit/model.py
+++ b/tests/unit/model.py
@@ -23,7 +23,6 @@
 
 from haas.model import *
 from haas import config
-from haas.ext.obm.ipmi import Ipmi
 
 from haas.test_common import fresh_database, config_testsuite, ModelTest, \
     fail_on_log_warnings
@@ -47,6 +46,7 @@ pytestmark = pytest.mark.usefixtures('configure', 'fresh_database')
 class TestNic(ModelTest):
 
     def sample_obj(self):
+        from haas.ext.obm.ipmi import Ipmi
         return Nic(Node(label='node-99',
                         obm=Ipmi(type=Ipmi.api_name,
                                  host="ipmihost",
@@ -58,6 +58,7 @@ class TestNic(ModelTest):
 class TestNode(ModelTest):
 
     def sample_obj(self):
+        from haas.ext.obm.ipmi import Ipmi
         return Node(label='node-99',
                     obm=Ipmi(type=Ipmi.api_name,
                              host="ipmihost",
@@ -96,6 +97,7 @@ class TestNetwork(ModelTest):
 class TestNetworkingAction(ModelTest):
 
     def sample_obj(self):
+        from haas.ext.obm.ipmi import Ipmi
         nic = Nic(Node(label='node-99',
                        obm=Ipmi(type=Ipmi.api_name,
                                 host="ipmihost",

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -46,3 +46,14 @@ def test_no_raise_non_haas(level, loggername):
     logger = logging.getLogger(loggername)
     logfn = getattr(logger, level)
     logfn("Somebody else's bug.")
+
+
+def test_dont_pollute_other_tests_extensions():
+    """Regression test for #697."""
+    import sys
+    for name in sys.modules.keys():
+        assert not name.startswith('haas.ext.'), (
+            "No extensions should have been loaded, but %r was. This may "
+            "mean that tests are polluting each others' set of loaded "
+            "extensions." % name
+        )


### PR DESCRIPTION
This patch avoids loading things under haas.ext at top level, since that
happens during test collection, and thus pollutes the environment of
tests that don't use those extensions.

It also includes a regression test.

//cc @shwsun, @knikolla, @henn 