### PR TITLE
Fix #695: discrepancy with default parameter names in list_network_attachments() 

### DIFF
--- a/haas/cli.py
+++ b/haas/cli.py
@@ -107,7 +107,6 @@ class KeystoneHTTPClient(HTTPClient):
         # We have to import this here, since we can't assume the library
         # is available from global scope.
         from keystoneauth1.exceptions.http import HttpError
-
         try:
             # The order of these parameters is different that what
             # we expect, but the names are the same:
@@ -116,8 +115,8 @@ class KeystoneHTTPClient(HTTPClient):
                                         data=data,
                                         params=params)
         except HttpError as e:
-            return e.response
-
+	    return e.response
+	    
 
 # An instance of HTTPClient, which will be used to make the request.
 http_client = None
@@ -670,12 +669,10 @@ def list_network_attachments(network, project):
     <project> may be either "all" or a specific project name.
     """
     url = object_url('network', network, 'attachments')
-
     if project == "all":
         do_get(url)
     else:
-        do_get(url, data={'project': project})
-
+        do_get(url, params={'project': project})
 
 @cmd
 def list_nodes(is_free):
@@ -830,6 +827,6 @@ def main():
         try:
             command_dict[sys.argv[1]](*sys.argv[2:])
         except FailedAPICallException:
-            sys.exit(1)
+	    sys.exit(1)
         except InvalidAPIArgumentsException:
-            sys.exit(2)
+	    sys.exit(2)

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -674,7 +674,7 @@ def list_network_attachments(network, project):
     if project == "all":
         do_get(url)
     else:
-        do_get(url, data={'project': project})
+        do_get(url, params={'project': project})
 
 
 @cmd

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -107,6 +107,7 @@ class KeystoneHTTPClient(HTTPClient):
         # We have to import this here, since we can't assume the library
         # is available from global scope.
         from keystoneauth1.exceptions.http import HttpError
+
         try:
             # The order of these parameters is different that what
             # we expect, but the names are the same:
@@ -115,8 +116,8 @@ class KeystoneHTTPClient(HTTPClient):
                                         data=data,
                                         params=params)
         except HttpError as e:
-	    return e.response
-	    
+            return e.response
+
 
 # An instance of HTTPClient, which will be used to make the request.
 http_client = None
@@ -669,10 +670,12 @@ def list_network_attachments(network, project):
     <project> may be either "all" or a specific project name.
     """
     url = object_url('network', network, 'attachments')
+
     if project == "all":
         do_get(url)
     else:
-        do_get(url, params={'project': project})
+        do_get(url, data={'project': project})
+
 
 @cmd
 def list_nodes(is_free):
@@ -827,6 +830,6 @@ def main():
         try:
             command_dict[sys.argv[1]](*sys.argv[2:])
         except FailedAPICallException:
-	    sys.exit(1)
+            sys.exit(1)
         except InvalidAPIArgumentsException:
-	    sys.exit(2)
+            sys.exit(2)


### PR DESCRIPTION
This PR fixes #695 . The parameter name for projects in `list_network_attachments()` of cli.py used data= instead of params= which is what `do_get()` in cli.py is expecting. This commit fixes that.