### PR TITLE
Updated the Brocade driver to enable the switchport when setting mode

### DIFF
--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -259,12 +259,12 @@ class Brocade(Switch):
         # Double quotes are necessary in the url because switch ports contain
         # forward slashes (/), ex. 101/0/10 is encoded as "101/0/10".
         return '%(hostname)s/rest/config/running/interface/' \
-            '%(interface_type)s/%%22%(interface)s%%22/%(suffix)s' \
+            '%(interface_type)s/%%22%(interface)s%%22%(suffix)s' \
             % {
                   'hostname': self.hostname,
                   'interface_type': self.interface_type,
                   'interface': interface,
-                  'suffix': 'switchport/%s' % suffix if suffix else ''
+                  'suffix': '/switchport/%s' % suffix if suffix else ''
             }
 
     @property

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -120,13 +120,13 @@ class Brocade(Switch):
 
         """
         url = self._construct_url(interface, suffix='mode')
-        response = requests.get(url, auth=self._auth)
+        response = self._make_request('GET', url)
         root = etree.fromstring(response.text)
         mode = root.find(self._construct_tag('vlan-mode')).text
         return mode
 
-    def _set_mode(self, interface, mode):
-        """ Set the mode of an interface.
+    def _enable_and_set_mode(self, interface, mode):
+        """ Enables switching and sets the mode of an interface.
 
         Args:
             interface: interface to set the mode of
@@ -135,10 +135,16 @@ class Brocade(Switch):
         Raises: AssertionError if mode is invalid.
 
         """
+        # Enable switching
+        url = self._construct_url(interface)
+        payload = '<switchport></switchport>'
+        self._make_request('POST', url, data=payload)
+
+        # Set the interface mode
         if mode in ['access', 'trunk']:
             url = self._construct_url(interface, suffix='mode')
             payload = '<mode><vlan-mode>%s</vlan-mode></mode>' % mode
-            requests.put(url, data=payload, auth=self._auth)
+            self._make_request('PUT', url, data=payload)
         else:
             raise AssertionError('Invalid mode')
 
@@ -155,7 +161,7 @@ class Brocade(Switch):
         """
         try:
             url = self._construct_url(interface, suffix='trunk')
-            response = requests.get(url, auth=self._auth)
+            response = self._make_request('GET', url)
             root = etree.fromstring(response.text)
             vlans = root.\
                 find(self._construct_tag('allowed')).\
@@ -175,7 +181,7 @@ class Brocade(Switch):
         """
         try:
             url = self._construct_url(interface, suffix='trunk')
-            response = requests.get(url, auth=self._auth)
+            response = self._make_request('GET', url)
             root = etree.fromstring(response.text)
             vlan = root.find(self._construct_tag('native-vlan')).text
             return ('vlan/native', vlan)
@@ -191,10 +197,10 @@ class Brocade(Switch):
             interface: interface to add the vlan to
             vlan: vlan to add
         """
-        self._set_mode(interface, 'trunk')
+        self._enable_and_set_mode(interface, 'trunk')
         url = self._construct_url(interface, suffix='trunk/allowed/vlan')
         payload = '<vlan><add>%s</vlan></vlan>' % vlan
-        requests.put(url, data=payload, auth=self._auth)
+        self._make_request('PUT', url, data=payload)
 
     def _remove_vlan_from_trunk(self, interface, vlan):
         """ Remove a vlan from a trunk port.
@@ -205,7 +211,7 @@ class Brocade(Switch):
         """
         url = self._construct_url(interface, suffix='trunk/allowed/vlan')
         payload = '<vlan><remove>%s</remove></vlan>' % vlan
-        requests.put(url, data=payload, auth=self._auth)
+        self._make_request('PUT', url, data=payload)
 
     def _set_native_vlan(self, interface, vlan):
         """ Set the native vlan of an interface.
@@ -214,11 +220,11 @@ class Brocade(Switch):
             interface: interface to set the native vlan to
             vlan: vlan to set as the native vlan
         """
-        self._set_mode(interface, 'trunk')
+        self._enable_and_set_mode(interface, 'trunk')
         self._disable_native_tag(interface)
         url = self._construct_url(interface, suffix='trunk')
         payload = '<trunk><native-vlan>%s</native-vlan></trunk>' % vlan
-        requests.put(url, data=payload, auth=self._auth)
+        self._make_request('PUT', url, data=payload)
 
     def _remove_native_vlan(self, interface):
         """ Remove the native vlan from an interface.
@@ -227,7 +233,7 @@ class Brocade(Switch):
             interface: interface to remove the native vlan from
         """
         url = self._construct_url(interface, suffix='trunk/native-vlan')
-        requests.delete(url, auth=self._auth)
+        self._make_request('DELETE', url)
 
     def _disable_native_tag(self, interface):
         """ Disable tagging of the native vlan
@@ -237,9 +243,9 @@ class Brocade(Switch):
 
         """
         url = self._construct_url(interface, suffix='trunk/tag/native-vlan')
-        response = requests.delete(url, auth=self._auth)
+        self._make_request('DELETE', url)
 
-    def _construct_url(self, interface, suffix=None):
+    def _construct_url(self, interface, suffix=''):
         """ Construct the API url for a specific interface appending suffix.
 
         Args:
@@ -253,12 +259,12 @@ class Brocade(Switch):
         # Double quotes are necessary in the url because switch ports contain
         # forward slashes (/), ex. 101/0/10 is encoded as "101/0/10".
         return '%(hostname)s/rest/config/running/interface/' \
-            '%(interface_type)s/%%22%(interface)s%%22/switchport/%(suffix)s' \
+            '%(interface_type)s/%%22%(interface)s%%22/%(suffix)s' \
             % {
                   'hostname': self.hostname,
                   'interface_type': self.interface_type,
                   'interface': interface,
-                  'suffix': suffix
+                  'suffix': 'switchport/%s' % suffix if suffix else ''
             }
 
     @property
@@ -269,3 +275,9 @@ class Brocade(Switch):
     def _construct_tag(name):
         """ Construct the xml tag by prepending the brocade tag prefix. """
         return '{urn:brocade.com:mgmt:brocade-interface}%s' % name
+
+    def _make_request(self, method, url, data=None):
+        r = requests.request(method, url, data=data, auth=self._auth)
+        if r.status_code >= 400:
+            logger.error('Bad Request to switch. Response: %s' % r.text)
+        return r

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -274,3 +274,14 @@ class TestBrocade(object):
             assert mock.called
             assert mock.call_count == 1
             assert mock.request_history[0].text == TRUNK_REMOVE_VLAN_PAYLOAD
+
+    def test_construct_url(self, switch):
+        assert switch._construct_url('1/0/4') == (
+            'http://example.com/rest/config/running/interface/'
+            'TenGigabitEthernet/%221/0/4%22'
+        )
+
+        assert switch._construct_url('1/0/4', suffix='mode') == (
+            'http://example.com/rest/config/running/interface/'
+            'TenGigabitEthernet/%221/0/4%22/switchport/mode'
+        )

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -208,6 +208,8 @@ class TestBrocade(object):
                                                new_network=network,
                                                channel='vlan/native')
         with requests_mock.mock() as mock:
+            url_switch = switch._construct_url(INTERFACE1)
+            mock.post(url_switch)
             url_mode = switch._construct_url(INTERFACE1, suffix='mode')
             mock.put(url_mode)
             url_tag = switch._construct_url(INTERFACE1,
@@ -219,9 +221,9 @@ class TestBrocade(object):
             switch.apply_networking(action_native)
 
             assert mock.called
-            assert mock.call_count == 3
-            assert mock.request_history[0].text == TRUNK_PAYLOAD
-            assert mock.request_history[2].text == TRUNK_NATIVE_PAYLOAD
+            assert mock.call_count == 4
+            assert mock.request_history[1].text == TRUNK_PAYLOAD
+            assert mock.request_history[3].text == TRUNK_NATIVE_PAYLOAD
 
         # Test action to remove a native network
         action_rm_native = model.NetworkingAction(nic=nic,
@@ -242,6 +244,8 @@ class TestBrocade(object):
                                              new_network=network,
                                              channel='vlan/102')
         with requests_mock.mock() as mock:
+            url_switch = switch._construct_url(INTERFACE1)
+            mock.post(url_switch)
             url_mode = switch._construct_url(INTERFACE1,
                                              suffix='mode')
             mock.put(url_mode)
@@ -252,9 +256,9 @@ class TestBrocade(object):
             switch.apply_networking(action_vlan)
 
             assert mock.called
-            assert mock.call_count == 2
-            assert mock.request_history[0].text == TRUNK_PAYLOAD
-            assert mock.request_history[1].text == TRUNK_VLAN_PAYLOAD
+            assert mock.call_count == 3
+            assert mock.request_history[1].text == TRUNK_PAYLOAD
+            assert mock.request_history[2].text == TRUNK_VLAN_PAYLOAD
 
         # Test action to remove a vlan
         action_rm_vlan = model.NetworkingAction(nic=nic,

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -99,6 +99,8 @@ TRUNK_NATIVE_VLAN_RESPONSE_WITH_VLANS = """
 </trunk>
 """
 
+SWITCHPORT_PAYLOAD = '<switchport></switchport>'
+
 TRUNK_PAYLOAD = '<mode><vlan-mode>trunk</vlan-mode></mode>'
 
 TRUNK_NATIVE_PAYLOAD = '<trunk><native-vlan>102</native-vlan></trunk>'
@@ -222,6 +224,7 @@ class TestBrocade(object):
 
             assert mock.called
             assert mock.call_count == 4
+            assert mock.request_history[0].text == SWITCHPORT_PAYLOAD
             assert mock.request_history[1].text == TRUNK_PAYLOAD
             assert mock.request_history[3].text == TRUNK_NATIVE_PAYLOAD
 
@@ -257,6 +260,7 @@ class TestBrocade(object):
 
             assert mock.called
             assert mock.call_count == 3
+            assert mock.request_history[0].text == SWITCHPORT_PAYLOAD
             assert mock.request_history[1].text == TRUNK_PAYLOAD
             assert mock.request_history[2].text == TRUNK_VLAN_PAYLOAD
 


### PR DESCRIPTION
This step had to previously be done by the administrator through the
commandline interface by issuing the command ``switchport``. It
is now automated by the HIL driver by issuing an API call to
enable switching on the interface before the driver sets the port.