### PR TITLE
Get rid of SQLALCHEMY_TRACK_MODIFICATIONS warnings

### DIFF
--- a/haas/model.py
+++ b/haas/model.py
@@ -32,13 +32,13 @@ from haas.dev_support import no_dry_run
 import uuid
 import xml.etree.ElementTree
 
-db = SQLAlchemy(app)
-
 # without setting this explicitly, we get a warning that this option
 # will default to disabled in future versions (due to incurring a lot
 # of overhed). We aren't using the relevant functionality, so let's
 # just opt-in to the change now:
 app.config.update(SQLALCHEMY_TRACK_MODIFICATIONS=False)
+
+db = SQLAlchemy(app)
 
 
 def init_db(uri=None):


### PR DESCRIPTION
Get rid of SQLALCHEMY_TRACK_MODIFICATIONS warnings by setting Flask's app.config sooner.

Fixes #703