### PR TITLE
Restricts FlaskSQLAlchemy to 2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,9 @@ setup(name='haas',
       #
       # [1]: http://semver.org
       # [2]: https://packaging.python.org/en/latest/distributing/#choosing-a-versioning-scheme  # noqa
+      #
+      # For Flask-SQLAlchemy, we are using non-standard semver bounds as
+      # release 2.2 is backwards-incompatible.
       install_requires=['Flask-SQLAlchemy>=2.1,<2.2',
                         'Flask-Migrate>=1.8,<2.0',
                         'Flask-Script>=2.0.5,<3.0',

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(name='haas',
       #
       # [1]: http://semver.org
       # [2]: https://packaging.python.org/en/latest/distributing/#choosing-a-versioning-scheme  # noqa
-      install_requires=['Flask-SQLAlchemy>=2.1,<3.0',
+      install_requires=['Flask-SQLAlchemy>=2.1,<2.2',
                         'Flask-Migrate>=1.8,<2.0',
                         'Flask-Script>=2.0.5,<3.0',
                         'Werkzeug>=0.9.4,<0.10',


### PR DESCRIPTION
Issue #729 
Flask-SQLAlchemy was recently updated to 2.2 which breaks our tests (and rightly so). 

This PR restricts it to an older version unless we figure out how to reorder the fixtures the right way (I am on it, but might take me a while).  
@zenhack @shwsun @henn 
 