### PR TITLE
Use upper contraints file for keystone, set version to newton

### DIFF
--- a/ci/keystone/install.sh
+++ b/ci/keystone/install.sh
@@ -5,4 +5,4 @@ pip install python-keystoneclient
 # The exact commit we use here is somewhat arbitrary, but we want
 # something that (a) won't change out from under our feet, and (b)
 # works with our existing tests.
-keystone_commit=10.0.0.0rc3 ./ci/keystone/keystone.sh setup
+keystone_commit=stable/newton ./ci/keystone/keystone.sh setup

--- a/ci/keystone/keystone.sh
+++ b/ci/keystone/keystone.sh
@@ -45,12 +45,11 @@ case "$1" in
     # too old to parse some of the syntax used in keystone's requirements.txt.
     # Make sure we have the latest:
     pip install --upgrade pip
-    
-    # The latest oslo.policy requires a weird version of requests that
-    # conflicts with other things as of 2017/03/07. See #734
-    pip install 'oslo.policy<1.19.0'
 
-    pip install -r requirements.txt
+    # Use the constraints file to provide an upper bound for package versions.
+    pip install \
+        -r requirements.txt \
+        -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=${keystone_commit}
     pip install .
     pip install uwsgi # To actually run keystone; no webserver in the deps.
 
@@ -64,7 +63,9 @@ case "$1" in
     pid=$!
     # Doing this after launching keystone will give it plenty of time to get
     # started without adding any wasteful calls to sleep:
-    pip install python-openstackclient
+    pip install -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=${keystone_commit} \
+        python-openstackclient
+
     source ../keystonerc # for $OS_PASSWORD
     ADMIN_PASSWORD=s3cr3t ./tools/sample_data.sh
 


### PR DESCRIPTION
OpenStack uses an upper contraint file to prevent package version
conflicts among the different projects. This file is available
at [0]. You can request an upper contraints file for a specific
version of OpenStack by appending "?h=stable/version", such as
"?h=stable/ocata", for the latest stable version.

Since this requires using stable branches and doesn't support
tags for the version you require, I switched from using
a specific tag, to using the stable branch netwon.

Not using ocata because ocata defaults to using fernet tokens,
which need to be setup.

0. https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt