### PR TITLE
Fix Deployment tests for brocade

### DIFF
--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -252,6 +252,9 @@ class Brocade(Switch):
         # % escapes the % character.
         # Double quotes are necessary in the url because switch ports contain
         # forward slashes (/), ex. 101/0/10 is encoded as "101/0/10".
+        if not isinstance(interface, basestring):
+            interface = interface.label
+
         return '%(hostname)s/rest/config/running/interface/' \
             '%(interface_type)s/%%22%(interface)s%%22/switchport/%(suffix)s' \
             % {

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -104,8 +104,9 @@ class Brocade(Switch):
         """
         response = {}
         for port in ports:
-            response[port] = filter(None, [self._get_native_vlan(port)]) \
-                             + self._get_vlans(port)
+            response[port] = filter(None,
+                                    [self._get_native_vlan(port.label)]) \
+                                    + self._get_vlans(port.label)
         return response
 
     def _get_mode(self, interface):
@@ -252,9 +253,6 @@ class Brocade(Switch):
         # % escapes the % character.
         # Double quotes are necessary in the url because switch ports contain
         # forward slashes (/), ex. 101/0/10 is encoded as "101/0/10".
-        if not isinstance(interface, basestring):
-            interface = interface.label
-
         return '%(hostname)s/rest/config/running/interface/' \
             '%(interface_type)s/%%22%(interface)s%%22/switchport/%(suffix)s' \
             % {

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -165,25 +165,30 @@ class TestBrocade(object):
 
     def test_get_port_networks(self, switch):
         with requests_mock.mock() as mock:
+
+            PORT1 = model.Port(label=INTERFACE1, switch=switch)
+            PORT2 = model.Port(label=INTERFACE2, switch=switch)
+            PORT3 = model.Port(label=INTERFACE3, switch=switch)
+
             mock.get(switch._construct_url(INTERFACE1, suffix='trunk'),
                      text=TRUNK_NATIVE_VLAN_RESPONSE_WITH_VLANS)
             mock.get(switch._construct_url(INTERFACE2, suffix='trunk'),
                      text=TRUNK_NATIVE_VLAN_RESPONSE_NO_VLANS)
             mock.get(switch._construct_url(INTERFACE3, suffix='trunk'),
                      text=TRUNK_VLAN_RESPONSE)
-            response = switch.get_port_networks([INTERFACE1,
-                                                 INTERFACE2,
-                                                 INTERFACE3])
+            response = switch.get_port_networks([PORT1,
+                                                 PORT2,
+                                                 PORT3])
             assert response == {
-                INTERFACE1: [('vlan/native', '10'),
-                             ('vlan/4001', '4001'),
-                             ('vlan/4025', '4025')],
-                INTERFACE2: [('vlan/native', '10')],
-                INTERFACE3: [('vlan/1', '1'),
-                             ('vlan/4001', '4001'),
-                             ('vlan/4004', '4004'),
-                             ('vlan/4025', '4025'),
-                             ('vlan/4050', '4050')]
+                PORT1: [('vlan/native', '10'),
+                        ('vlan/4001', '4001'),
+                        ('vlan/4025', '4025')],
+                PORT2: [('vlan/native', '10')],
+                PORT3: [('vlan/1', '1'),
+                        ('vlan/4001', '4001'),
+                        ('vlan/4004', '4004'),
+                        ('vlan/4025', '4025'),
+                        ('vlan/4050', '4050')]
             }
 
     def test_get_mode(self, switch):


### PR DESCRIPTION
Some methods (used by the deployment tests) were passing the class objects as a part of the URL which the switch doesn't understand. So I have set a filter to convert it to string before passing it to the switch. 

This fixes the deployment tests for the brocade switch. 

@knikolla @zenhack