### PR TITLE
Brocade driver: disable logging for _disable_native_tag and when renabling the switchport

### DIFF
--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -139,7 +139,7 @@ class Brocade(Switch):
         # Enable switching
         url = self._construct_url(interface)
         payload = '<switchport></switchport>'
-        self._make_request('POST', url, data=payload)
+        self._make_request('POST', url, data=payload, log=False)
 
         # Set the interface mode
         if mode in ['access', 'trunk']:
@@ -244,7 +244,7 @@ class Brocade(Switch):
 
         """
         url = self._construct_url(interface, suffix='trunk/tag/native-vlan')
-        self._make_request('DELETE', url)
+        self._make_request('DELETE', url, log=False)
 
     def _construct_url(self, interface, suffix=''):
         """ Construct the API url for a specific interface appending suffix.
@@ -277,8 +277,8 @@ class Brocade(Switch):
         """ Construct the xml tag by prepending the brocade tag prefix. """
         return '{urn:brocade.com:mgmt:brocade-interface}%s' % name
 
-    def _make_request(self, method, url, data=None):
+    def _make_request(self, method, url, data=None, log=True):
         r = requests.request(method, url, data=data, auth=self._auth)
-        if r.status_code >= 400:
+        if (r.status_code >= 400 and log):
             logger.error('Bad Request to switch. Response: %s' % r.text)
         return r

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -139,7 +139,8 @@ class Brocade(Switch):
         # Enable switching
         url = self._construct_url(interface)
         payload = '<switchport></switchport>'
-        self._make_request('POST', url, data=payload, log=False)
+        self._make_request('POST', url, data=payload,
+                           acceptable_error_codes=[409])
 
         # Set the interface mode
         if mode in ['access', 'trunk']:
@@ -244,7 +245,7 @@ class Brocade(Switch):
 
         """
         url = self._construct_url(interface, suffix='trunk/tag/native-vlan')
-        self._make_request('DELETE', url, log=False)
+        self._make_request('DELETE', url, acceptable_error_codes=[404])
 
     def _construct_url(self, interface, suffix=''):
         """ Construct the API url for a specific interface appending suffix.
@@ -277,8 +278,11 @@ class Brocade(Switch):
         """ Construct the xml tag by prepending the brocade tag prefix. """
         return '{urn:brocade.com:mgmt:brocade-interface}%s' % name
 
-    def _make_request(self, method, url, data=None, log=True):
+    def _make_request(self, method, url, data=None,
+                      acceptable_error_codes=None):
         r = requests.request(method, url, data=data, auth=self._auth)
-        if (r.status_code >= 400 and log):
+        acceptable_error_codes = acceptable_error_codes or []
+        if r.status_code >= 400 and \
+           r.status_code not in acceptable_error_codes:
             logger.error('Bad Request to switch. Response: %s' % r.text)
         return r

--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -140,7 +140,7 @@ class Brocade(Switch):
         url = self._construct_url(interface)
         payload = '<switchport></switchport>'
         self._make_request('POST', url, data=payload,
-                           acceptable_error_codes=[409])
+                           acceptable_error_codes=(409,))
 
         # Set the interface mode
         if mode in ['access', 'trunk']:
@@ -245,7 +245,7 @@ class Brocade(Switch):
 
         """
         url = self._construct_url(interface, suffix='trunk/tag/native-vlan')
-        self._make_request('DELETE', url, acceptable_error_codes=[404])
+        self._make_request('DELETE', url, acceptable_error_codes=(404,))
 
     def _construct_url(self, interface, suffix=''):
         """ Construct the API url for a specific interface appending suffix.
@@ -279,9 +279,8 @@ class Brocade(Switch):
         return '{urn:brocade.com:mgmt:brocade-interface}%s' % name
 
     def _make_request(self, method, url, data=None,
-                      acceptable_error_codes=None):
+                      acceptable_error_codes=()):
         r = requests.request(method, url, data=data, auth=self._auth)
-        acceptable_error_codes = acceptable_error_codes or []
         if r.status_code >= 400 and \
            r.status_code not in acceptable_error_codes:
             logger.error('Bad Request to switch. Response: %s' % r.text)


### PR DESCRIPTION
#748 

the switch returns 409 when renabling the switchport and 404 when we call
_disable_native_tag (called by _set_native_vlan). Due to this, the deployment
tests would fail. So this PR disables logging for these 2 cases.

@knikolla