### PR TITLE
Fixes a typo in the client library

### DIFF
--- a/haas/client/node.py
+++ b/haas/client/node.py
@@ -36,7 +36,7 @@ class Node(ClientBase):
     def delete(self, node_name):
         """Deletes the node from database. """
         url = self.object_url('node', node_name)
-        return check_response(self.httpClient.request('DELETE', url))
+        return self.check_response(self.httpClient.request('DELETE', url))
 
     def power_cycle(self, node_name):
         """Power cycles the <node> """


### PR DESCRIPTION
appends `self` for node delete which was missing. @knikolla @SahilTikale 