### PR TITLE
Fix typo in logger.info in rest.py

### DIFF
--- a/haas/rest.py
+++ b/haas/rest.py
@@ -276,7 +276,7 @@ def _rest_wrapper(f, schema, dont_log):
 
         init_auth()
         logger.info('API call: %s(%s)',
-                    (f.__name__, _format_arglist(**censored_kwargs)))
+                    f.__name__, _format_arglist(**censored_kwargs))
 
         ret = f(**kwargs)
         if ret is None:


### PR DESCRIPTION
It was changed [here](https://github.com/CCI-MOC/hil/pull/741/files#diff-b5f9a9866804160b5d674a46f72fc34eR278). We changed the `%` to `,` but forgot to remove the brackets. Without this the logger function litters the debug messages. 
```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/logging/__init__.py", line 851, in emit
    msg = self.format(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 724, in format
    return fmt.format(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 464, in format
    record.message = record.getMessage()
  File "/usr/lib64/python2.7/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
TypeError: not enough arguments for format string
```
