### PR TITLE
Upgrade pip in Travis CI to prevent dependency errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ env:
   - DB=postgres
 
 install:
-  - pip install --upgrade pip # Prevent old pip incompatibilities.
+  # A dependency might use new pip syntax; upgrade to prevent breakage. See #771
+  - pip install --upgrade pip
   - sh -e ci/apache/install.sh
   - sh -e ci/keystone/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - DB=postgres
 
 install:
+  - pip install --upgrade pip # Prevent old pip incompatibilities.
   - sh -e ci/apache/install.sh
   - sh -e ci/keystone/install.sh
 


### PR DESCRIPTION
Due to an old pip version, we got bit by the problem
fixed in one of HIL's dependencies, python requests. (see https://github.com/kennethreitz/requests/pull/4007).

The problem was due to requests using some functionality in the latest version of pip that wasn't in the older one installed in the Travis CI VM. The fix I made to prevent this sort of problem was to upgrade pip at the beginning of the run.

FYI - I left keystone's own `pip install --update pip` in place, since it starts a fresh virtualenv and thus shouldn't inherit this one anyhow.

The problem occurred in #767, though unfortunately the evidence is gone now since I restarted the build; the requests team fixed it (good timing!).