### PR TITLE
Add port details to show_node

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -537,11 +537,31 @@ Response body:
 	 "metadata":{"EK":"pk"}
 	}
 
+
+Response body if run by an admin:
+
+    {"name": "node1",
+	 "project": "project1",
+         "nics": [{"label": "nic1",
+           "port": "gi1/0/1",
+           "switch": "dell-01",
+	 	   "macaddr": "01:23:45:67:89", 
+		   "networks": {"vlan/native": "pxe", "vlan/235": "storage"}},
+                  {"label": "nic2",
+                   "port": None,
+                   "switch": None,
+		   "macaddr": "12:34:56:78:90", 
+		   "networks":{"vlan/native": "public"}}],
+	 "metadata":{"EK":"pk"}
+	}
+
 Authorization requirements:
 
 * If the node is free, no special access is required.
 * Otherwise, access to the project to which `<node>` is assigned is
   required.
+* If a user is an admin, then information about the port and switch to which
+  the nic is connected to is also printed.
 
 ### Projects
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -523,9 +523,11 @@ The object will have at least the following fields:
                 - "macaddr", the nic's mac address.
 		- "networks", a JSON object describing what networks are attached to the nic. The keys are channels and the values are the names of networks attached to those channels.
         - "port", the port to which the nic is connected to or null if the nic
-          is not connected to any port.
+          is not connected to any port. This field is only visibile if the
+          caller is an admin.
         - "switch", the switch that has the port to which the nic is connected
-          to or null if the nic is not connected to any port.
+          to or null if the nic is not connected to any port. Just like port,
+          this is only visible if the caller is an admin.
 	* "metadata", a dictionary of metadata objects
 
 Response body when run by a non-admin user:

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -522,46 +522,73 @@ The object will have at least the following fields:
                 - "label", the nic's label.
                 - "macaddr", the nic's mac address.
 		- "networks", a JSON object describing what networks are attached to the nic. The keys are channels and the values are the names of networks attached to those channels.
+        - "port", the port to which the nic is connected to or null if the nic
+          is not connected to any port.
+        - "switch", the switch that has the port to which the nic is connected
+          to or null if the nic is not connected to any port.
 	* "metadata", a dictionary of metadata objects
 
-Response body:
+Response body when run by a non-admin user:
 
-    {"name": "node1",
-	 "project": "project1",
-         "nics": [{"label": "nic1", 
-	 	   "macaddr": "01:23:45:67:89", 
-		   "networks": {"vlan/native": "pxe", "vlan/235": "storage"}},
-                  {"label": "nic2", 
-		   "macaddr": "12:34:56:78:90", 
-		   "networks":{"vlan/native": "public"}}],
-	 "metadata":{"EK":"pk"}
-	}
+    {
+        "metadata": {
+            "EK": "pk"
+        },
+        "name": "node1",
+        "nics": [
+            {
+                "label": "nic1",
+                "macaddr": "01:23:45:67:89",
+                "networks": {
+                    "vlan/235": "storage",
+                    "vlan/native": "pxe"
+                }
+            },
+            {
+                "label": "nic2",
+                "macaddr": "12:34:56:78:90",
+                "networks": {}
+            }
+        ],
+        "project": "project1"
+    }
 
 
-Response body if run by an admin:
+Response body when run by an admin:
 
-    {"name": "node1",
-	 "project": "project1",
-         "nics": [{"label": "nic1",
-           "port": "gi1/0/1",
-           "switch": "dell-01",
-	 	   "macaddr": "01:23:45:67:89", 
-		   "networks": {"vlan/native": "pxe", "vlan/235": "storage"}},
-                  {"label": "nic2",
-                   "port": None,
-                   "switch": None,
-		   "macaddr": "12:34:56:78:90", 
-		   "networks":{"vlan/native": "public"}}],
-	 "metadata":{"EK":"pk"}
-	}
+    {
+        "metadata": {
+            "EK": "pk"
+        },
+        "name": "node1",
+        "nics": [
+            {
+                "label": "nic1",
+                "macaddr": "01:23:45:67:89",
+                "networks": {
+                    "vlan/235": "storage",
+                    "vlan/native": "pxe"
+                },
+                "port": "gi1/0/1",
+                "switch": "dell-01"
+            },
+            {
+                "label": "nic2",
+                "macaddr": "12:34:56:78:90",
+                "networks": {},
+                "port": null,
+                "switch": null
+            }
+        ],
+        "project": "project1"
+    }
 
 Authorization requirements:
 
 * If the node is free, no special access is required.
 * Otherwise, access to the project to which `<node>` is assigned is
   required.
-* If a user is an admin, then information about the port and switch to which
-  the nic is connected to is also printed.
+* Admin acces to view port and switch information.
 
 ### Projects
 

--- a/haas/api.py
+++ b/haas/api.py
@@ -1143,6 +1143,8 @@ def show_node(nodename):
         'project': None if node.project_id is None else node.project.label,
         'nics': [{'label': n.label,
                   'macaddr': n.mac_addr,
+                  'port': None if n.port is None else n.port.label,
+                  'switch': None if n.port is None else n.port.owner.label,
                   'networks': dict([(attachment.channel,
                                      attachment.network.label)
                                     for attachment in n.attachments]),

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -716,9 +716,7 @@ def show_node(node):
 #    via this call. Suggestion to future developers of CLI to use
 #    recursion in the call for output of such metadata.
 
-    q = check_clientlib_response(lambda: C.node.show(node))
-    for item in q.items():
-        sys.stdout.write("%s\t  :  %s\n" % (item[0], item[1]))
+    print check_clientlib_response(lambda: C.node.show(node))
 
 
 @cmd

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -716,7 +716,9 @@ def show_node(node):
 #    via this call. Suggestion to future developers of CLI to use
 #    recursion in the call for output of such metadata.
 
-    print check_clientlib_response(lambda: C.node.show(node))
+    q = check_clientlib_response(lambda: C.node.show(node))
+    for item in q.items():
+        print item
 
 
 @cmd

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -718,7 +718,7 @@ def show_node(node):
 
     q = check_clientlib_response(lambda: C.node.show(node))
     for item in q.items():
-        print item
+        sys.stdout.write("%s\t  :  %s\n" % (item[0], item[1]))
 
 
 @cmd

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -1856,11 +1856,15 @@ class TestQuery_unpopulated_db:
                 {
                     'label': 'eth0',
                     'macaddr': 'DE:AD:BE:EF:20:14',
+                    'port': None,
+                    'switch': None,
                     "networks": {}
                 },
                 {
                     'label': 'wlan0',
                     'macaddr': 'DE:AD:BE:EF:20:15',
+                    'port': None,
+                    'switch': None,
                     "networks": {}
                 }
             ],
@@ -1889,11 +1893,15 @@ class TestQuery_unpopulated_db:
                 {
                     'label': 'eth0',
                     'macaddr': 'DE:AD:BE:EF:20:14',
+                    'port': None,
+                    'switch': None,
                     "networks": {}
                 },
                 {
                     'label': 'wlan0',
                     'macaddr': 'DE:AD:BE:EF:20:15',
+                    'port': None,
+                    'switch': None,
                     "networks": {}
                 }
             ],
@@ -1935,6 +1943,8 @@ class TestQuery_unpopulated_db:
                 {
                     'label': 'eth0',
                     'macaddr': 'DE:AD:BE:EF:20:14',
+                    'port': '1',
+                    'switch': 'sw0',
                     "networks": {
                         get_network_allocator().get_default_channel(): 'pxe'
                     }
@@ -1942,6 +1952,8 @@ class TestQuery_unpopulated_db:
                 {
                     'label': 'wlan0',
                     'macaddr': 'DE:AD:BE:EF:20:15',
+                    'port': '2',
+                    'switch': 'sw0',
                     "networks": {
                         get_network_allocator().get_default_channel(): 'storage'  # noqa
                     }

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -308,6 +308,8 @@ class Test_node:
                 u'nics': [
                     {
                         u'macaddr': u'aa:bb:cc:dd:ee:07',
+                        u'port': u'gi1/0/7',
+                        u'switch': u'mock-01',
                         u'networks': {}, u'label': u'eth0'
                         }
                     ],


### PR DESCRIPTION
Now the user can see what port and switch the node is connected to. It's a part of the `show_node` command. 

The [comment](https://github.com/CCI-MOC/hil/pull/767#issuecomment-298133016) and PR #767 that led to this. 