### PR TITLE
Refuse to run as root

### DIFF
--- a/haas/cli.py
+++ b/haas/cli.py
@@ -15,6 +15,7 @@
 """This module implements the HaaS command line tool."""
 from haas import config, server, migrations
 from haas.config import cfg
+from haas.commands.util import ensure_not_root
 
 import inspect
 import json
@@ -806,6 +807,7 @@ def main():
     There is a script located at ${source_tree}/scripts/haas, which invokes
     this function.
     """
+    ensure_not_root()
     config.setup()
 
     if len(sys.argv) < 2 or sys.argv[1] not in command_dict:

--- a/haas/commands/admin.py
+++ b/haas/commands/admin.py
@@ -1,5 +1,6 @@
 from haas import config, model
 from haas.commands import db
+from haas.commands.util import ensure_not_root
 from haas.flaskapp import app
 from flask.ext.script import Manager
 
@@ -9,6 +10,7 @@ manager.add_command('db', db.command)
 
 def main():
     """Entrypoint for the haas-admin command."""
+    ensure_not_root()
     config.setup()
     model.init_db()
     manager.run()

--- a/haas/commands/util.py
+++ b/haas/commands/util.py
@@ -1,0 +1,12 @@
+"""Helpers used in various commands."""
+import os
+import sys
+
+
+def ensure_not_root():
+    """
+    Verify that we aren't running as root, exiting with an error otherwise.
+    """
+    if os.getuid() == 0:
+        sys.exit("You're running %s as root. Don't do this -- use "
+                 "a regular user account. Exiting." % sys.argv[0])


### PR DESCRIPTION
Fixes #387

Note that I didn't bother with checking the db permissions; actually getting that right is a bit finicky, and refusing to run as root will prevent most cases of that in the first place. (As discussed there, given that this only affects sqlite, it's unlikely to come up much in practice, since  folks will mostly be using postgres in prod).

Re: testing, I did manual verification of this (both positive and negitive, with both affected commands), but thought it not worth trying to write unit tests that run the commands as root -- the impact of a bug is relatively low, and it complicates the test infrastructure a bit.

//cc @henn, @naved001, @knikolla 