### PR TITLE
sleep() in serve_networks() tunable via cfg

### DIFF
--- a/examples/haas.cfg
+++ b/examples/haas.cfg
@@ -91,7 +91,7 @@ uri = sqlite:////absolute/path/to/haas.db
 
 [network-daemon]
 # The amount of time in seconds to sleep after attempting to empty the journal 
-# when running serve_networks. Range is 0 < sleep_time < 3600. Default is 2:
+# when running serve_networks. If set, must be > 0 and < 3600. Default is 2:
 #sleep_time=
 
 [extensions]

--- a/examples/haas.cfg
+++ b/examples/haas.cfg
@@ -91,7 +91,9 @@ uri = sqlite:////absolute/path/to/haas.db
 
 [network-daemon]
 # The amount of time in seconds to sleep after attempting to empty the journal 
-# when running serve_networks. If set, must be > 0 and < 3600. Default is 2:
+# when running serve_networks. If set, must be > 0 and < 3600 (1 hour). A
+# warning will be logged if sleep_time is greater than 60 (1 minute).
+# Default value if unset is 2:
 #sleep_time=
 
 [extensions]

--- a/examples/haas.cfg
+++ b/examples/haas.cfg
@@ -88,6 +88,10 @@ uri = sqlite:////absolute/path/to/haas.db
 # ``dry_run`` is present (regardless of its value), this functionality is
 # enabled:
 #dry_run=
+#
+# The amount of time in seconds to sleep after attempting to empty the journal 
+# in the serve_networks command.  Default in haas/cli.py is 2 seconds:
+#sleep_time=
 
 [extensions]
 # List of extensions to load. The values should all be empty. See

--- a/examples/haas.cfg
+++ b/examples/haas.cfg
@@ -91,7 +91,7 @@ uri = sqlite:////absolute/path/to/haas.db
 
 [network-daemon]
 # The amount of time in seconds to sleep after attempting to empty the journal 
-# when running serve_networks.  Default time is 2 seconds:
+# when running serve_networks. Range is 0 < sleep_time < 3600. Default is 2:
 #sleep_time=
 
 [extensions]

--- a/examples/haas.cfg
+++ b/examples/haas.cfg
@@ -88,9 +88,10 @@ uri = sqlite:////absolute/path/to/haas.db
 # ``dry_run`` is present (regardless of its value), this functionality is
 # enabled:
 #dry_run=
-#
+
+[network-daemon]
 # The amount of time in seconds to sleep after attempting to empty the journal 
-# in the serve_networks command.  Default in haas/cli.py is 2 seconds:
+# when running serve_networks.  Default time is 2 seconds:
 #sleep_time=
 
 [extensions]

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -257,12 +257,12 @@ def serve_networks():
     # Check if config contains usable sleep_time
     if cfg.has_option('network-daemon', 'sleep_time'):
         try:
-            sleep_time = float(cfg.get('network-daemon', 'sleep_time'))
-            if sleep_time < 0:
-                raise ValueError
+            sleep_time = cfg.getfloat('network-daemon', 'sleep_time')
         except (ValueError):
-            sys.exit("Error: Invalid sleep_time. " \
-                     "Must be a positive decimal value\n")
+            sys.exit("Error: sleep_time set to non-float value\n")
+        if sleep_time <= 0 or sleep_time >= 3600:
+            sys.exit("Error: sleep_time not within bounds " \
+                     "0 < sleep_time < 3600\n")
     else:
         sleep_time = 2
 

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -253,12 +253,19 @@ def serve_networks():
     server.validate_state()
     model.init_db()
     migrations.check_db_schema()
+
     # Check if config contains usable sleep_time
-    try:
-        sleep_time = float(cfg.get('devel', 'sleep_time'))
-    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError,
-            ValueError):
+    if cfg.has_option('network-daemon', 'sleep_time'):
+        try:
+            sleep_time = float(cfg.get('network-daemon', 'sleep_time'))
+            if sleep_time < 0:
+                raise ValueError
+        except (ValueError):
+            sys.exit("Error: Invalid sleep_time. " \
+                     "Must be a positive decimal value\n")
+    else:
         sleep_time = 2
+
     while True:
         # Empty the journal until it's empty; then delay so we don't tight
         # loop.

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -247,11 +247,14 @@ def serve_networks():
     """Start the HaaS networking server"""
     from haas import model, deferred
     from time import sleep
+    import logging
     server.init()
     server.register_drivers()
     server.validate_state()
     model.init_db()
     migrations.check_db_schema()
+
+    logger = logging.getLogger(__name__)
 
     # Check if config contains usable sleep_time
     if (cfg.has_section('network-daemon') and
@@ -264,7 +267,7 @@ def serve_networks():
             sys.exit("Error: sleep_time not within bounds "
                      "0 < sleep_time < 3600")
         if sleep_time > 60:
-            sys.stdout.write("Warning: sleep_time greater than 1 minute\n")
+            logger.warn('sleep_time greater than 1 minute.')
     else:
         sleep_time = 2
 

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -263,6 +263,8 @@ def serve_networks():
         if sleep_time <= 0 or sleep_time >= 3600:
             sys.exit("Error: sleep_time not within bounds "
                      "0 < sleep_time < 3600")
+        if sleep_time > 60:
+            sys.stdout.write("Warning: sleep_time greater than 1 minute\n")
     else:
         sleep_time = 2
 

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -247,7 +247,6 @@ def serve_networks():
     """Start the HaaS networking server"""
     from haas import model, deferred
     from time import sleep
-    import ConfigParser
     server.init()
     server.register_drivers()
     server.validate_state()
@@ -255,7 +254,8 @@ def serve_networks():
     migrations.check_db_schema()
 
     # Check if config contains usable sleep_time
-    if cfg.has_option('network-daemon', 'sleep_time'):
+    if (cfg.has_section('network-daemon') and
+            cfg.has_option('network-daemon', 'sleep_time')):
         try:
             sleep_time = cfg.getfloat('network-daemon', 'sleep_time')
         except (ValueError):

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -261,7 +261,7 @@ def serve_networks():
         except (ValueError):
             sys.exit("Error: sleep_time set to non-float value\n")
         if sleep_time <= 0 or sleep_time >= 3600:
-            sys.exit("Error: sleep_time not within bounds " \
+            sys.exit("Error: sleep_time not within bounds "
                      "0 < sleep_time < 3600\n")
     else:
         sleep_time = 2

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -259,10 +259,10 @@ def serve_networks():
         try:
             sleep_time = cfg.getfloat('network-daemon', 'sleep_time')
         except (ValueError):
-            sys.exit("Error: sleep_time set to non-float value\n")
+            sys.exit("Error: sleep_time set to non-float value")
         if sleep_time <= 0 or sleep_time >= 3600:
             sys.exit("Error: sleep_time not within bounds "
-                     "0 < sleep_time < 3600\n")
+                     "0 < sleep_time < 3600")
     else:
         sleep_time = 2
 

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -23,6 +23,7 @@ import requests
 import sys
 import urllib
 import schema
+import logging
 
 from functools import wraps
 
@@ -30,6 +31,7 @@ from haas.client.client import Client, RequestsHTTPClient, KeystoneHTTPClient
 from haas.client.base import FailedAPICallException
 
 
+logger = logging.getLogger(__name__)
 command_dict = {}
 usage_dict = {}
 MIN_PORT_NUMBER = 1
@@ -247,14 +249,11 @@ def serve_networks():
     """Start the HaaS networking server"""
     from haas import model, deferred
     from time import sleep
-    import logging
     server.init()
     server.register_drivers()
     server.validate_state()
     model.init_db()
     migrations.check_db_schema()
-
-    logger = logging.getLogger(__name__)
 
     # Check if config contains usable sleep_time
     if (cfg.has_section('network-daemon') and

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -247,17 +247,24 @@ def serve_networks():
     """Start the HaaS networking server"""
     from haas import model, deferred
     from time import sleep
+    import ConfigParser
     server.init()
     server.register_drivers()
     server.validate_state()
     model.init_db()
     migrations.check_db_schema()
+    # Check if config contains usable sleep_time
+    try:
+        sleep_time = float(cfg.get('devel', 'sleep_time'))
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError,
+            ValueError):
+        sleep_time = 2
     while True:
         # Empty the journal until it's empty; then delay so we don't tight
         # loop.
         while deferred.apply_networking():
             pass
-        sleep(2)
+        sleep(sleep_time)
 
 
 @cmd


### PR DESCRIPTION
- In response to issue #318 :
- The sleep() time in serve_networks() can now be set in the configuration file under [devel].
- The default sleep() time is 2 seconds if it is not read from haas.cfg
- In the dev branch there is a solution where serve_networks() is passed the sleep() time as a parameter.  However, this may not be necessary if the desired sleep() time will only be set by the config file.