### PR TITLE
Check for well formed port names

### DIFF
--- a/examples/dbinit.py
+++ b/examples/dbinit.py
@@ -10,7 +10,7 @@ In the example environment for which this module is written, there are 10
 nodes which have IPMI interfaces that are sequentially numbered starting with
 10.0.0.0, have a username of "ADMIN_USER" and password of "ADMIN_PASSWORD".
 The ports are also numbered sequentially and are named following a dell switch
-scheme, which have ports that look like "R10SW1::GI1/0/5"
+scheme, which have ports that look like "gi1/0/5"
 
 It could be used in an environment similar to the one which
 ``hil.cfg`` corresponds, though could also be used for development with the
@@ -36,7 +36,7 @@ hil('switch_register', switch, 'mock', 'ip', 'user', 'pass')
 for node in range(N_NODES):
     ipmi_ip = "10.0.0." + str(node + 1)
 
-    nic_port = "R10SW1::GI1/0/%d" % (node)
+    nic_port = "gi1/0/%d" % (node)
     nic_name = 'nic1'
     hil('node_register', node, "mock", ipmi_ip, ipmi_user, ipmi_pass)
     hil('node_register_nic', node, nic_name, 'FillThisInLater')

--- a/hil/api.py
+++ b/hil/api.py
@@ -920,6 +920,9 @@ def switch_register_port(switch, port):
     get_auth_backend().require_admin()
     switch = _must_find(model.Switch, switch)
     _assert_absent_n(switch, model.Port, port)
+
+    switch.validate_port_name(port)
+
     port = model.Port(port, switch)
 
     db.session.add(port)

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -64,7 +64,8 @@ class Brocade(Switch):
 
         val = re.compile(r'^\d+/\d+(/\d+)?$')
         if not val.match(port):
-            raise BadArgumentError("Invalid port name")
+            raise BadArgumentError("Invalid port name. Valid port names for "
+                                   "this switch are of the from 1/0/1 or 1/2")
         return
 
     def disconnect(self):

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -26,6 +26,7 @@ import schema
 
 from hil.migrations import paths
 from hil.model import db, Switch
+from hil.errors import BadArgumentError
 
 paths[__name__] = join(dirname(__file__), 'migrations', 'brocade')
 
@@ -56,6 +57,13 @@ class Brocade(Switch):
 
     def session(self):
         return self
+
+    @staticmethod
+    def validate_port_name(port):
+        val = re.compile('(^\d+\/\d+\/\d+$)|(^\d+\/\d+$)')
+        if not val.match(port):
+            raise BadArgumentError("Invalid port name")
+        return
 
     def disconnect(self):
         pass

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -62,7 +62,7 @@ class Brocade(Switch):
     def validate_port_name(port):
         """Valid port names for this switch are of the form 1/0/1 or 1/2"""
 
-        val = re.compile('(^\d+\/\d+\/\d+$)|(^\d+\/\d+$)')
+        val = re.compile(r'^\d+/\d+(/\d+)?$')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")
         return

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -60,6 +60,8 @@ class Brocade(Switch):
 
     @staticmethod
     def validate_port_name(port):
+        """Valid port names for this switch are of the form 1/0/1 or 1/2"""
+
         val = re.compile('(^\d+\/\d+\/\d+$)|(^\d+\/\d+$)')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -66,7 +66,9 @@ class PowerConnect55xx(Switch):
 
         val = re.compile(r'^(gi|te)\d+/\d+(/\d+)?$')
         if not val.match(port):
-            raise BadArgumentError("Invalid port name")
+            raise BadArgumentError("Invalid port name. Valid port names for "
+                                   "this switch are of the form gi1/0/11, "
+                                   "te1/0/12, gi1/12, or te1/3")
         return
 
 

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -26,6 +26,7 @@ from hil.migrations import paths
 from hil.ext.switches import _console
 from hil.ext.switches._dell_base import _BaseSession
 from os.path import dirname, join
+from hil.errors import BadArgumentError
 
 paths[__name__] = join(dirname(__file__), 'migrations', 'dell')
 logger = logging.getLogger(__name__)
@@ -54,6 +55,13 @@ class PowerConnect55xx(Switch):
 
     def session(self):
         return _PowerConnect55xxSession.connect(self)
+
+    @staticmethod
+    def validate_port_name(port):
+        val = re.compile('(^(gi|te)\d+[/]\d+[/]\d+$)|(^(gi|te)\d+[/]\d+$)')
+        if not val.match(port)
+            raise BadArgumentError("Port name not cool for this switch")
+        return
 
 
 class _PowerConnect55xxSession(_BaseSession):

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -64,7 +64,7 @@ class PowerConnect55xx(Switch):
         te1/0/12, gi1/12, or te1/3
         """
 
-        val = re.compile('(^(gi|te)\d+[/]\d+[/]\d+$)|(^(gi|te)\d+[/]\d+$)')
+        val = re.compile(r'^(gi|te)\d+/\d+(/\d+)?$')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")
         return

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -20,6 +20,7 @@ the long term we want to be using SNMP.
 import pexpect
 import logging
 import schema
+import re
 
 from hil.model import db, Switch
 from hil.migrations import paths
@@ -59,8 +60,8 @@ class PowerConnect55xx(Switch):
     @staticmethod
     def validate_port_name(port):
         val = re.compile('(^(gi|te)\d+[/]\d+[/]\d+$)|(^(gi|te)\d+[/]\d+$)')
-        if not val.match(port)
-            raise BadArgumentError("Port name not cool for this switch")
+        if not val.match(port):
+            raise BadArgumentError("Invalid port name")
         return
 
 

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -59,6 +59,11 @@ class PowerConnect55xx(Switch):
 
     @staticmethod
     def validate_port_name(port):
+        """
+        Valid port names for this switch are of the form gi1/0/11,
+        te1/0/12, gi1/12, or te1/3
+        """
+
         val = re.compile('(^(gi|te)\d+[/]\d+[/]\d+$)|(^(gi|te)\d+[/]\d+$)')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")

--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -60,12 +60,16 @@ class MockSwitch(Switch):
 
     @staticmethod
     def validate_port_name(port):
-        """Valid port names for this switch are of the form 1/0/1 or 1/2"""
+        """
+        Valid port names for this switch are of the form gi1/0/11,
+        te1/0/12, gi1/12, or te1/3
+        """
 
-        val = re.compile(r'^\d+/\d+(/\d+)?$')
+        val = re.compile(r'^(gi|te)\d+/\d+(/\d+)?$')
         if not val.match(port):
-            raise BadArgumentError("Invalid port name: Vald port names are of"
-                                   " the form 1/0/1 or 1/2")
+            raise BadArgumentError("Invalid port name. Valid port names are "
+                                   "of the form gi1/0/11, te1/0/12, gi1/12,"
+                                   " te1/3")
         return
 
     def session(self):

--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -21,8 +21,10 @@ from collections import defaultdict
 from hil.model import Switch
 from hil.migrations import paths
 import schema
+import re
 from sqlalchemy import Column, Integer, ForeignKey, String
 from os.path import dirname, join
+from hil.errors import BadArgumentError
 
 paths[__name__] = join(dirname(__file__), 'migrations', 'mock')
 
@@ -58,8 +60,13 @@ class MockSwitch(Switch):
 
     @staticmethod
     def validate_port_name(port):
-        """All port names are valid for the mock switch"""
-        pass
+        """Valid port names for this switch are of the form 1/0/1 or 1/2"""
+
+        val = re.compile(r'^\d+/\d+(/\d+)?$')
+        if not val.match(port):
+            raise BadArgumentError("Invalid port name: Vald port names are of"
+                                   " the form 1/0/1 or 1/2")
+        return
 
     def session(self):
         return self

--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -58,6 +58,7 @@ class MockSwitch(Switch):
 
     @staticmethod
     def validate_port_name(port):
+        """All port names are valid for the mock switch"""
         pass
 
     def session(self):

--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -57,7 +57,7 @@ class MockSwitch(Switch):
         }).validate(kwargs)
 
     @staticmethod
-    def validate_port_name(self):
+    def validate_port_name(port):
         pass
 
     def session(self):

--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -67,9 +67,9 @@ class MockSwitch(Switch):
 
         val = re.compile(r'^(gi|te)\d+/\d+(/\d+)?$')
         if not val.match(port):
-            raise BadArgumentError("Invalid port name. Valid port names are "
-                                   "of the form gi1/0/11, te1/0/12, gi1/12,"
-                                   " te1/3")
+            raise BadArgumentError("Invalid port name. Valid port names for "
+                                   "this switch are of the form gi1/0/11, "
+                                   "te1/0/12, gi1/12, or te1/3")
         return
 
     def session(self):

--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -56,6 +56,10 @@ class MockSwitch(Switch):
             'password': basestring,
         }).validate(kwargs)
 
+    @staticmethod
+    def validate_port_name(self):
+        pass
+
     def session(self):
         return self
 

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -70,7 +70,7 @@ class DellN3000(Switch):
         te1/0/12, gi1/12, or te1/3
         """
 
-        val = re.compile('(^(gi|te)\d+[/]\d+[/]\d+$)|(^(gi|te)\d+[/]\d+$)')
+        val = re.compile(r'^(gi|te)\d+/\d+(/\d+)?$')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")
         return

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -65,6 +65,11 @@ class DellN3000(Switch):
 
     @staticmethod
     def validate_port_name(port):
+        """
+        Valid port names for this switch are of the form gi1/0/11,
+        te1/0/12, gi1/12, or te1/3
+        """
+
         val = re.compile('(^(gi|te)\d+[/]\d+[/]\d+$)|(^(gi|te)\d+[/]\d+$)')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -29,6 +29,7 @@ from hil.ext.switches import _console
 from hil.ext.switches._dell_base import _BaseSession
 from os.path import dirname, join
 from hil.migrations import paths
+from hil.errors import BadArgumentError
 
 logger = logging.getLogger(__name__)
 paths[__name__] = join(dirname(__file__), 'migrations', 'n3000')
@@ -61,6 +62,13 @@ class DellN3000(Switch):
 
     def session(self):
         return _DellN3000Session.connect(self)
+
+    @staticmethod
+    def validate_port_name(port):
+        val = re.compile('(^(gi|te)\d+[/]\d+[/]\d+$)|(^(gi|te)\d+[/]\d+$)')
+        if not val.match(port):
+            raise BadArgumentError("Invalid port name")
+        return
 
 
 class _DellN3000Session(_BaseSession):

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -72,7 +72,9 @@ class DellN3000(Switch):
 
         val = re.compile(r'^(gi|te)\d+/\d+(/\d+)?$')
         if not val.match(port):
-            raise BadArgumentError("Invalid port name")
+            raise BadArgumentError("Invalid port name. Valid port names for "
+                                   "this switch are of the form gi1/0/11, "
+                                   "te1/0/12, gi1/12, or te1/3")
         return
 
 

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -64,8 +64,7 @@ class Nexus(Switch):
         ethernet1/12, Ethernet1/0/10, or ethernet1/0/10
         """
 
-        val = re.compile(
-                '((E|e)thernet\d+\/\d+\/\d+$)|((E|e)thernet\d+\/\d+$)')
+        val = re.compile(r'^(E|e)thernet\d+/\d+(/\d+)?$')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")
         return

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -66,7 +66,10 @@ class Nexus(Switch):
 
         val = re.compile(r'^(E|e)thernet\d+/\d+(/\d+)?$')
         if not val.match(port):
-            raise BadArgumentError("Invalid port name")
+            raise BadArgumentError("Invalid port name. Valid port names for "
+                                   "this switch are of the form: Ethernet1/12"
+                                   " ethernet1/12, Ethernet1/0/10, or"
+                                   " ethernet1/0/10")
         return
 
 

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -59,8 +59,13 @@ class Nexus(Switch):
 
     @staticmethod
     def validate_port_name(port):
-        val = \
-         re.compile('((E|e)thernet\d+\/\d+\/\d+$)|((E|e)thernet\d+\/\d+$)')
+        """
+        Valid port names for this switch are of the form: Ethernet1/12,
+        ethernet1/12, Ethernet1/0/10, or ethernet1/0/10
+        """
+
+        val = re.compile(
+                '((E|e)thernet\d+\/\d+\/\d+$)|((E|e)thernet\d+\/\d+$)')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")
         return

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -25,6 +25,7 @@ import logging
 
 from hil.model import db, Switch
 from hil.ext.switches import _console
+from hil.errors import BadArgumentError
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,13 @@ class Nexus(Switch):
 
     def session(self):
         return _Session.connect(self)
+
+    @staticmethod
+    def validate_port_name(port):
+        val = re.compile('^((E|e)thernet\d+\/\d+\/\d+$)|((E|e)thernet\d+\/\d+$)')
+        if not val.match(port):
+            raise BadArgumentError("Invalid port name")
+        return
 
 
 class _Session(_console.Session):

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -59,7 +59,8 @@ class Nexus(Switch):
 
     @staticmethod
     def validate_port_name(port):
-        val = re.compile('^((E|e)thernet\d+\/\d+\/\d+$)|((E|e)thernet\d+\/\d+$)')
+        val = \
+         re.compile('((E|e)thernet\d+\/\d+\/\d+$)|((E|e)thernet\d+\/\d+$)')
         if not val.match(port):
             raise BadArgumentError("Invalid port name")
         return

--- a/hil/model.py
+++ b/hil/model.py
@@ -219,6 +219,11 @@ class Switch(db.Model):
         'polymorphic_on': type,
     }
 
+    def validate_port_name(self, port):
+        """Verify that port name is valid for switch"""
+
+        assert False, "Subclasses MUST override the validate method"
+
     @staticmethod
     def validate(kwargs):
         """Verify that ``kwargs`` is a legal set of keyword args to ``__init__``

--- a/tests/unit/api/auth.py
+++ b/tests/unit/api/auth.py
@@ -634,7 +634,7 @@ admin_calls = [
         'password': 'changeme',
     }),
     (api.switch_delete, ['empty-switch'], {}),
-    (api.switch_register_port, ['stock_switch_0', 'new_port'], {}),
+    (api.switch_register_port, ['stock_switch_0', 'gi1/0/13'], {}),
     (api.switch_delete_port, ['stock_switch_0', 'free_port_0'], {}),
     (api.port_connect_nic, ['stock_switch_0', 'free_port_0',
                             'free_node_0', 'boot-nic'], {}),

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -24,11 +24,7 @@ import uuid
 MOCK_SWITCH_TYPE = 'http://schema.massopencloud.org/haas/v0/switches/mock'
 OBM_TYPE_MOCK = 'http://schema.massopencloud.org/haas/v0/obm/mock'
 OBM_TYPE_IPMI = 'http://schema.massopencloud.org/haas/v0/obm/ipmi'
-PORT1 = 'gi1/0/1'
-PORT2 = 'gi1/0/2'
-PORT3 = 'gi1/0/3'
-PORT4 = 'gi1/0/4'
-PORT5 = 'gi1/0/5'
+PORTS = ['gi1/0/1', 'gi1/0/2', 'gi1/0/3', 'gi1/0/4', 'gi1/0/5']
 
 
 @pytest.fixture
@@ -65,7 +61,7 @@ def switchinit():
                         username="switch_user",
                         password="switch_pass",
                         hostname="switchname")
-    api.switch_register_port('sw0', PORT3)
+    api.switch_register_port('sw0', PORTS[2])
 
 
 default_fixtures = ['fail_on_log_warnings',
@@ -182,7 +178,7 @@ class TestNetworking:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        for port in PORT1, PORT2, PORT3:
+        for port in PORTS[0], PORTS[1], PORTS[2]:
             api.switch_register_port('sw0', port)
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
@@ -205,8 +201,8 @@ class TestNetworking:
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('node-98', 'eth0', 'DE:AD:BE:EF:20:15')
         api.node_register_nic('node-97', 'eth0', 'DE:AD:BE:EF:20:16')
-        for port, node in (PORT1, 'node-99'), (PORT2, 'node-98'), \
-                          (PORT3, 'node-97'):
+        for port, node in (PORTS[0], 'node-99'), (PORTS[1], 'node-98'), \
+                          (PORTS[2], 'node-97'):
             api.port_connect_nic('sw0', port, node, 'eth0')
 
         api.project_create('anvil-nextgen')
@@ -330,7 +326,7 @@ class TestProjectConnectDetachNode:
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
         with pytest.raises(api.BlockedError):
             api.project_detach_node('anvil-nextgen', 'node-99')
@@ -357,7 +353,7 @@ class TestProjectConnectDetachNode:
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
         deferred.apply_networking()
         api.node_detach_network('node-99', 'eth0', 'hammernet')
@@ -660,7 +656,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
 
         # Check the actual HTTP response and status, not just the success;
         # we should do this at least once in the test suite, since this call
@@ -684,7 +680,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
         api.node_register('node-98', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
@@ -782,7 +778,7 @@ class TestNodeConnectDetachNetwork:
         api.project_connect_node('anvil-nextgen', 'node-99')
 
         network_create_simple('hammernet', 'anvil-oldtimer')  # changed
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
 
         with pytest.raises(api.ProjectMismatchError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -798,7 +794,7 @@ class TestNodeConnectDetachNetwork:
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')  # added
         deferred.apply_networking()  # added
 
@@ -817,7 +813,7 @@ class TestNodeConnectDetachNetwork:
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         network_create_simple('hammernet2', 'anvil-nextgen')  # added
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')  # added
         deferred.apply_networking()  # added
 
@@ -834,7 +830,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
         deferred.apply_networking()  # added
 
@@ -878,7 +874,7 @@ class TestNodeConnectDetachNetwork:
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.project_connect_node('anvil-nextgen', 'node-98')  # added
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
@@ -899,7 +895,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
@@ -915,7 +911,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
@@ -931,7 +927,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
@@ -947,7 +943,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
 #        api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', '99-eth0')
 #        api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.ProjectMismatchError):
@@ -1310,7 +1306,7 @@ class TestNetworkCreateDelete:
                   "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.project_connect_node('anvil-nextgen', 'node-99')
-        api.port_connect_nic('sw0', PORT3, 'node-99', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
         deferred.apply_networking()
         api.node_detach_network('node-99', 'eth0', 'hammernet')
@@ -1332,7 +1328,7 @@ class TestNetworkCreateDelete:
                   "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.project_connect_node('anvil-nextgen', 'node-99')
-        api.port_connect_nic('sw0', PORT3, 'node-99', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
         with pytest.raises(api.BlockedError):
             api.network_delete('hammernet')
@@ -1399,15 +1395,15 @@ class Test_switch_register_port:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', PORT5)
+        api.switch_register_port('sw0', PORTS[4])
         port = model.Port.query.one()
-        assert port.label == PORT5
+        assert port.label == PORTS[4]
         assert port.owner.label == 'sw0'
 
     def test_register_port_nonexisting_switch(self):
         """Creating  port on a non-existant switch should fail."""
         with pytest.raises(api.NotFoundError):
-            api.switch_register_port('sw0', PORT5)
+            api.switch_register_port('sw0', PORTS[4])
 
 
 class Test_switch_delete_port:
@@ -1419,8 +1415,8 @@ class Test_switch_delete_port:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', PORT5)
-        api.switch_delete_port('sw0', PORT5)
+        api.switch_register_port('sw0', PORTS[4])
+        api.switch_delete_port('sw0', PORTS[4])
         assert model.Port.query.count() == 0
 
     def test_delete_port_nonexisting_switch(self):
@@ -1429,7 +1425,7 @@ class Test_switch_delete_port:
         report the error.
         """
         with pytest.raises(api.NotFoundError):
-            api.switch_delete_port('sw0', PORT5)
+            api.switch_delete_port('sw0', PORTS[4])
 
     def test_delete_port_nonexisting_port(self):
         """Removing a port that does not exist should report the error"""
@@ -1439,7 +1435,7 @@ class Test_switch_delete_port:
                             password="switch_pass",
                             hostname="switchname")
         with pytest.raises(api.NotFoundError):
-            api.switch_delete_port('sw0', PORT5)
+            api.switch_delete_port('sw0', PORTS[4])
 
 
 class Test_list_switches:
@@ -1479,16 +1475,16 @@ class Test_list_switches:
 
         assert json.loads(api.show_switch('sw0')) == {
             'name': 'sw0',
-            'ports': [{'label': PORT3}]
+            'ports': [{'label': PORTS[2]}]
         }
 
-        api.switch_register_port('sw0', PORT2)
+        api.switch_register_port('sw0', PORTS[1])
         # Note: the order of ports is not sorted, test cases need to be in the
         # same order.
         assert json.loads(api.show_switch('sw0')) == {
             'name': 'sw0',
-            'ports': [{'label': PORT3},
-                      {'label': PORT2}]
+            'ports': [{'label': PORTS[2]},
+                      {'label': PORTS[1]}]
         }
 
 
@@ -1508,10 +1504,10 @@ class TestShowPort:
         with pytest.raises(api.NotFoundError):
             api.show_port('sw0', 'non-existing-port')
 
-        assert json.loads(api.show_port('sw0', PORT3)) == {}
+        assert json.loads(api.show_port('sw0', PORTS[2])) == {}
         # connect the port to a nic, and see if show port agrees
-        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
-        assert json.loads(api.show_port('sw0', PORT3)) == {
+        api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
+        assert json.loads(api.show_port('sw0', PORTS[2])) == {
                         'node': u'compute-01',
                         'nic': 'eth0',
                         'networks': {}}
@@ -1526,7 +1522,7 @@ class TestPortConnectDetachNic:
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_switch(self):
         api.node_register('compute-01', obm={
@@ -1536,7 +1532,7 @@ class TestPortConnectDetachNic:
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
-            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_port(self):
         api.switch_register('sw0',
@@ -1551,7 +1547,7 @@ class TestPortConnectDetachNic:
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
-            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_node(self):
         api.switch_register('sw0',
@@ -1559,9 +1555,9 @@ class TestPortConnectDetachNic:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', PORT3)
+        api.switch_register_port('sw0', PORTS[2])
         with pytest.raises(api.NotFoundError):
-            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_nic(self):
         api.switch_register('sw0',
@@ -1569,14 +1565,14 @@ class TestPortConnectDetachNic:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', PORT3)
+        api.switch_register_port('sw0', PORTS[2])
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
                   "user": "root",
                   "password": "tapeworm"})
         with pytest.raises(api.NotFoundError):
-            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
 
     def test_port_connect_nic_already_attached_to_same(self, switchinit):
         api.node_register('compute-01', obm={
@@ -1585,22 +1581,22 @@ class TestPortConnectDetachNic:
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
         with pytest.raises(api.DuplicateError):
-            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
 
     def test_port_connect_nic_nic_already_attached_differently(self,
                                                                switchinit):
-        api.switch_register_port('sw0', PORT4)
+        api.switch_register_port('sw0', PORTS[3])
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
         with pytest.raises(api.DuplicateError):
-            api.port_connect_nic('sw0', PORT4, 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORTS[3], 'compute-01', 'eth0')
 
     def test_port_connect_nic_port_already_attached_differently(self,
                                                                 switchinit):
@@ -1616,9 +1612,9 @@ class TestPortConnectDetachNic:
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('compute-02', 'eth1', 'DE:AD:BE:EF:20:15')
-        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
         with pytest.raises(api.DuplicateError):
-            api.port_connect_nic('sw0', PORT3, 'compute-02', 'eth1')
+            api.port_connect_nic('sw0', PORTS[2], 'compute-02', 'eth1')
 
     def test_port_detach_nic_success(self, switchinit):
         api.node_register('compute-01', obm={
@@ -1627,12 +1623,12 @@ class TestPortConnectDetachNic:
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
-        api.port_detach_nic('sw0', PORT3)
+        api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
+        api.port_detach_nic('sw0', PORTS[2])
 
     def test_port_detach_nic_no_such_port(self):
         with pytest.raises(api.NotFoundError):
-            api.port_detach_nic('sw0', PORT3)
+            api.port_detach_nic('sw0', PORTS[2])
 
     def test_port_detach_nic_not_attached(self):
         api.switch_register('sw0',
@@ -1640,7 +1636,7 @@ class TestPortConnectDetachNic:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', PORT3)
+        api.switch_register_port('sw0', PORTS[2])
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1648,7 +1644,7 @@ class TestPortConnectDetachNic:
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
-            api.port_detach_nic('sw0', PORT3)
+            api.port_detach_nic('sw0', PORTS[2])
 
     def port_detach_nic_node_not_free(self, switchinit):
         """should refuse to detach a nic if it has pending actions."""
@@ -1658,13 +1654,13 @@ class TestPortConnectDetachNic:
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORTS[2], 'compute-01', 'eth0')
 
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'compute-01')
 
         with pytest.raises(api.BlockedError):
-            api.port_detach_nic('sw0', PORT3)
+            api.port_detach_nic('sw0', PORTS[2])
 
 
 class TestQuery_populated_db:
@@ -1921,8 +1917,8 @@ class TestQuery_unpopulated_db:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', PORT1)
-        api.switch_register_port('sw0', PORT2)
+        api.switch_register_port('sw0', PORTS[0])
+        api.switch_register_port('sw0', PORTS[1])
         api.node_register('robocop', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1934,10 +1930,10 @@ class TestQuery_unpopulated_db:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'robocop')
         network_create_simple('pxe', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT1, 'robocop', 'eth0')
+        api.port_connect_nic('sw0', PORTS[0], 'robocop', 'eth0')
         api.node_connect_network('robocop', 'eth0', 'pxe')
         network_create_simple('storage', 'anvil-nextgen')
-        api.port_connect_nic('sw0', PORT2, 'robocop', 'wlan0')
+        api.port_connect_nic('sw0', PORTS[1], 'robocop', 'wlan0')
         api.node_connect_network('robocop', 'wlan0', 'storage')
         deferred.apply_networking()
 
@@ -1949,7 +1945,7 @@ class TestQuery_unpopulated_db:
                 {
                     'label': 'eth0',
                     'macaddr': 'DE:AD:BE:EF:20:14',
-                    'port': PORT1,
+                    'port': PORTS[0],
                     'switch': 'sw0',
                     "networks": {
                         get_network_allocator().get_default_channel(): 'pxe'
@@ -1958,7 +1954,7 @@ class TestQuery_unpopulated_db:
                 {
                     'label': 'wlan0',
                     'macaddr': 'DE:AD:BE:EF:20:15',
-                    'port': PORT2,
+                    'port': PORTS[1],
                     'switch': 'sw0',
                     "networks": {
                         get_network_allocator().get_default_channel(): 'storage'  # noqa

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -24,6 +24,11 @@ import uuid
 MOCK_SWITCH_TYPE = 'http://schema.massopencloud.org/haas/v0/switches/mock'
 OBM_TYPE_MOCK = 'http://schema.massopencloud.org/haas/v0/obm/mock'
 OBM_TYPE_IPMI = 'http://schema.massopencloud.org/haas/v0/obm/ipmi'
+PORT1 = 'gi1/0/1'
+PORT2 = 'gi1/0/2'
+PORT3 = 'gi1/0/3'
+PORT4 = 'gi1/0/4'
+PORT5 = 'gi1/0/5'
 
 
 @pytest.fixture
@@ -60,7 +65,7 @@ def switchinit():
                         username="switch_user",
                         password="switch_pass",
                         hostname="switchname")
-    api.switch_register_port('sw0', '3')
+    api.switch_register_port('sw0', PORT3)
 
 
 default_fixtures = ['fail_on_log_warnings',
@@ -177,7 +182,7 @@ class TestNetworking:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        for port in '1', '2', '3':
+        for port in PORT1, PORT2, PORT3:
             api.switch_register_port('sw0', port)
         api.node_register('node-99', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
@@ -200,7 +205,8 @@ class TestNetworking:
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('node-98', 'eth0', 'DE:AD:BE:EF:20:15')
         api.node_register_nic('node-97', 'eth0', 'DE:AD:BE:EF:20:16')
-        for port, node in ('1', 'node-99'), ('2', 'node-98'), ('3', 'node-97'):
+        for port, node in (PORT1, 'node-99'), (PORT2, 'node-98'), \
+                          (PORT3, 'node-97'):
             api.port_connect_nic('sw0', port, node, 'eth0')
 
         api.project_create('anvil-nextgen')
@@ -324,7 +330,7 @@ class TestProjectConnectDetachNode:
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
         with pytest.raises(api.BlockedError):
             api.project_detach_node('anvil-nextgen', 'node-99')
@@ -351,7 +357,7 @@ class TestProjectConnectDetachNode:
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:13')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
         deferred.apply_networking()
         api.node_detach_network('node-99', 'eth0', 'hammernet')
@@ -654,7 +660,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
 
         # Check the actual HTTP response and status, not just the success;
         # we should do this at least once in the test suite, since this call
@@ -678,7 +684,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
         api.node_register('node-98', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
@@ -776,7 +782,7 @@ class TestNodeConnectDetachNetwork:
         api.project_connect_node('anvil-nextgen', 'node-99')
 
         network_create_simple('hammernet', 'anvil-oldtimer')  # changed
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
 
         with pytest.raises(api.ProjectMismatchError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
@@ -792,7 +798,7 @@ class TestNodeConnectDetachNetwork:
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
 
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')  # added
         deferred.apply_networking()  # added
 
@@ -811,7 +817,7 @@ class TestNodeConnectDetachNetwork:
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
         network_create_simple('hammernet2', 'anvil-nextgen')  # added
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')  # added
         deferred.apply_networking()  # added
 
@@ -828,7 +834,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
         deferred.apply_networking()  # added
 
@@ -872,7 +878,7 @@ class TestNodeConnectDetachNetwork:
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.project_connect_node('anvil-nextgen', 'node-98')  # added
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
@@ -893,7 +899,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
@@ -909,7 +915,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
@@ -925,7 +931,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.NotFoundError):
@@ -941,7 +947,7 @@ class TestNodeConnectDetachNetwork:
         api.project_create('anvil-nextgen')
 #        api.project_connect_node('anvil-nextgen', 'node-99')
         network_create_simple('hammernet', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '3', 'node-99', '99-eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', '99-eth0')
 #        api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         with pytest.raises(api.ProjectMismatchError):
@@ -1304,7 +1310,7 @@ class TestNetworkCreateDelete:
                   "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.project_connect_node('anvil-nextgen', 'node-99')
-        api.port_connect_nic('sw0', '3', 'node-99', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
         deferred.apply_networking()
         api.node_detach_network('node-99', 'eth0', 'hammernet')
@@ -1326,7 +1332,7 @@ class TestNetworkCreateDelete:
                   "password": "tapeworm"})
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
         api.project_connect_node('anvil-nextgen', 'node-99')
-        api.port_connect_nic('sw0', '3', 'node-99', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
         with pytest.raises(api.BlockedError):
             api.network_delete('hammernet')
@@ -1393,15 +1399,15 @@ class Test_switch_register_port:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', '5')
+        api.switch_register_port('sw0', PORT5)
         port = model.Port.query.one()
-        assert port.label == '5'
+        assert port.label == PORT5
         assert port.owner.label == 'sw0'
 
     def test_register_port_nonexisting_switch(self):
         """Creating  port on a non-existant switch should fail."""
         with pytest.raises(api.NotFoundError):
-            api.switch_register_port('sw0', '5')
+            api.switch_register_port('sw0', PORT5)
 
 
 class Test_switch_delete_port:
@@ -1413,8 +1419,8 @@ class Test_switch_delete_port:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', '5')
-        api.switch_delete_port('sw0', '5')
+        api.switch_register_port('sw0', PORT5)
+        api.switch_delete_port('sw0', PORT5)
         assert model.Port.query.count() == 0
 
     def test_delete_port_nonexisting_switch(self):
@@ -1423,7 +1429,7 @@ class Test_switch_delete_port:
         report the error.
         """
         with pytest.raises(api.NotFoundError):
-            api.switch_delete_port('sw0', '5')
+            api.switch_delete_port('sw0', PORT5)
 
     def test_delete_port_nonexisting_port(self):
         """Removing a port that does not exist should report the error"""
@@ -1433,7 +1439,7 @@ class Test_switch_delete_port:
                             password="switch_pass",
                             hostname="switchname")
         with pytest.raises(api.NotFoundError):
-            api.switch_delete_port('sw0', '5')
+            api.switch_delete_port('sw0', PORT5)
 
 
 class Test_list_switches:
@@ -1473,16 +1479,16 @@ class Test_list_switches:
 
         assert json.loads(api.show_switch('sw0')) == {
             'name': 'sw0',
-            'ports': [{'label': '3'}]
+            'ports': [{'label': PORT3}]
         }
 
-        api.switch_register_port('sw0', 'test_port')
+        api.switch_register_port('sw0', PORT2)
         # Note: the order of ports is not sorted, test cases need to be in the
         # same order.
         assert json.loads(api.show_switch('sw0')) == {
             'name': 'sw0',
-            'ports': [{'label': '3'},
-                      {'label': 'test_port'}]
+            'ports': [{'label': PORT3},
+                      {'label': PORT2}]
         }
 
 
@@ -1502,10 +1508,10 @@ class TestShowPort:
         with pytest.raises(api.NotFoundError):
             api.show_port('sw0', 'non-existing-port')
 
-        assert json.loads(api.show_port('sw0', '3')) == {}
+        assert json.loads(api.show_port('sw0', PORT3)) == {}
         # connect the port to a nic, and see if show port agrees
-        api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
-        assert json.loads(api.show_port('sw0', '3')) == {
+        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+        assert json.loads(api.show_port('sw0', PORT3)) == {
                         'node': u'compute-01',
                         'nic': 'eth0',
                         'networks': {}}
@@ -1520,7 +1526,7 @@ class TestPortConnectDetachNic:
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_switch(self):
         api.node_register('compute-01', obm={
@@ -1530,7 +1536,7 @@ class TestPortConnectDetachNic:
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
-            api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_port(self):
         api.switch_register('sw0',
@@ -1545,7 +1551,7 @@ class TestPortConnectDetachNic:
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
-            api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_node(self):
         api.switch_register('sw0',
@@ -1553,9 +1559,9 @@ class TestPortConnectDetachNic:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', '3')
+        api.switch_register_port('sw0', PORT3)
         with pytest.raises(api.NotFoundError):
-            api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_nic(self):
         api.switch_register('sw0',
@@ -1563,14 +1569,14 @@ class TestPortConnectDetachNic:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', '3')
+        api.switch_register_port('sw0', PORT3)
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
                   "user": "root",
                   "password": "tapeworm"})
         with pytest.raises(api.NotFoundError):
-            api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
 
     def test_port_connect_nic_already_attached_to_same(self, switchinit):
         api.node_register('compute-01', obm={
@@ -1579,22 +1585,22 @@ class TestPortConnectDetachNic:
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
         with pytest.raises(api.DuplicateError):
-            api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
 
     def test_port_connect_nic_nic_already_attached_differently(self,
                                                                switchinit):
-        api.switch_register_port('sw0', '4')
+        api.switch_register_port('sw0', PORT4)
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
         with pytest.raises(api.DuplicateError):
-            api.port_connect_nic('sw0', '4', 'compute-01', 'eth0')
+            api.port_connect_nic('sw0', PORT4, 'compute-01', 'eth0')
 
     def test_port_connect_nic_port_already_attached_differently(self,
                                                                 switchinit):
@@ -1610,9 +1616,9 @@ class TestPortConnectDetachNic:
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         api.node_register_nic('compute-02', 'eth1', 'DE:AD:BE:EF:20:15')
-        api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
         with pytest.raises(api.DuplicateError):
-            api.port_connect_nic('sw0', '3', 'compute-02', 'eth1')
+            api.port_connect_nic('sw0', PORT3, 'compute-02', 'eth1')
 
     def test_port_detach_nic_success(self, switchinit):
         api.node_register('compute-01', obm={
@@ -1621,12 +1627,12 @@ class TestPortConnectDetachNic:
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
-        api.port_detach_nic('sw0', '3')
+        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
+        api.port_detach_nic('sw0', PORT3)
 
     def test_port_detach_nic_no_such_port(self):
         with pytest.raises(api.NotFoundError):
-            api.port_detach_nic('sw0', '3')
+            api.port_detach_nic('sw0', PORT3)
 
     def test_port_detach_nic_not_attached(self):
         api.switch_register('sw0',
@@ -1634,7 +1640,7 @@ class TestPortConnectDetachNic:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', '3')
+        api.switch_register_port('sw0', PORT3)
         api.node_register('compute-01', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1642,7 +1648,7 @@ class TestPortConnectDetachNic:
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
-            api.port_detach_nic('sw0', '3')
+            api.port_detach_nic('sw0', PORT3)
 
     def port_detach_nic_node_not_free(self, switchinit):
         """should refuse to detach a nic if it has pending actions."""
@@ -1652,13 +1658,13 @@ class TestPortConnectDetachNic:
                   "user": "root",
                   "password": "tapeworm"})
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
-        api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
+        api.port_connect_nic('sw0', PORT3, 'compute-01', 'eth0')
 
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'compute-01')
 
         with pytest.raises(api.BlockedError):
-            api.port_detach_nic('sw0', '3')
+            api.port_detach_nic('sw0', PORT3)
 
 
 class TestQuery_populated_db:
@@ -1915,8 +1921,8 @@ class TestQuery_unpopulated_db:
                             username="switch_user",
                             password="switch_pass",
                             hostname="switchname")
-        api.switch_register_port('sw0', '1')
-        api.switch_register_port('sw0', '2')
+        api.switch_register_port('sw0', PORT1)
+        api.switch_register_port('sw0', PORT2)
         api.node_register('robocop', obm={
                   "type": "http://schema.massopencloud.org/haas/v0/obm/ipmi",
                   "host": "ipmihost",
@@ -1928,10 +1934,10 @@ class TestQuery_unpopulated_db:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'robocop')
         network_create_simple('pxe', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '1', 'robocop', 'eth0')
+        api.port_connect_nic('sw0', PORT1, 'robocop', 'eth0')
         api.node_connect_network('robocop', 'eth0', 'pxe')
         network_create_simple('storage', 'anvil-nextgen')
-        api.port_connect_nic('sw0', '2', 'robocop', 'wlan0')
+        api.port_connect_nic('sw0', PORT2, 'robocop', 'wlan0')
         api.node_connect_network('robocop', 'wlan0', 'storage')
         deferred.apply_networking()
 
@@ -1943,7 +1949,7 @@ class TestQuery_unpopulated_db:
                 {
                     'label': 'eth0',
                     'macaddr': 'DE:AD:BE:EF:20:14',
-                    'port': '1',
+                    'port': PORT1,
                     'switch': 'sw0',
                     "networks": {
                         get_network_allocator().get_default_channel(): 'pxe'
@@ -1952,7 +1958,7 @@ class TestQuery_unpopulated_db:
                 {
                     'label': 'wlan0',
                     'macaddr': 'DE:AD:BE:EF:20:15',
-                    'port': '2',
+                    'port': PORT2,
                     'switch': 'sw0',
                     "networks": {
                         get_network_allocator().get_default_channel(): 'storage'  # noqa

--- a/tests/unit/api/port_register.py
+++ b/tests/unit/api/port_register.py
@@ -1,0 +1,134 @@
+# Copyright 2013-2017 Massachusetts Open Cloud Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS
+# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied.  See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Unit tests for port_register"""
+from hil import api, server
+from hil.test_common import config_testsuite, config_merge, config, \
+    fail_on_log_warnings, with_request_context, fresh_database
+import pytest
+
+BROCADE = 'http://schema.massopencloud.org/haas/v0/switches/brocade'
+DELL = 'http://schema.massopencloud.org/haas/v0/switches/powerconnect55xx'
+NEXUS = 'http://schema.massopencloud.org/haas/v0/switches/nexus'
+
+
+@pytest.fixture
+def configure():
+    config_testsuite()
+    config_merge({
+        'extensions': {
+            'hil.ext.switches.brocade': '',
+            'hil.ext.switches.dell': '',
+            'hil.ext.switches.nexus': '',
+        },
+    })
+    config.load_extensions()
+
+
+fresh_database = pytest.fixture(fresh_database)
+fail_on_log_warnings = pytest.fixture(fail_on_log_warnings)
+
+
+@pytest.fixture
+def server_init():
+    server.register_drivers()
+    server.validate_state()
+
+
+with_request_context = pytest.yield_fixture(with_request_context)
+
+default_fixtures = ['fail_on_log_warnings',
+                    'configure',
+                    'fresh_database',
+                    'server_init',
+                    'with_request_context']
+
+pytestmark = pytest.mark.usefixtures(*default_fixtures)
+
+
+class TestPortValidate:
+
+    def test_register_port_invalid_name_brocade(self):
+        """Registering a port with an invalid name should fail"""
+
+        api.switch_register('brocade', type=BROCADE,
+                            username="switch_user",
+                            password="switch_pass",
+                            hostname="switchname",
+                            interface_type="Tengigabitethernet")
+
+        # test some random invalid port names for brocade switch
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('brocade', 'blah-blah')
+
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('brocade', '1/q/1')
+
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('brocade', '1/12/32q')
+
+        # register some valid port names
+        api.switch_register_port('brocade', '1/0/12')
+        api.switch_register_port('brocade', '1/12')
+
+    def test_register_port_invalid_name_nexus(self):
+        """Registering a port with an invalid name should fail"""
+
+        api.switch_register('nexus', type=NEXUS,
+                            username="switch_user",
+                            password="switch_pass",
+                            hostname="switchname",
+                            dummy_vlan=2222)
+
+        # test some random invalid port names for cisco nexus
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('nexus', 'blah-blah')
+
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('nexus', 'eethernet1/2')
+
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('nexus', 'Ethernet1')
+
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('nexus', 'Ethernet/12')
+
+        # register some valid port names
+        api.switch_register_port('nexus', 'Ethernet1/8')
+        api.switch_register_port('nexus', 'Ethernet1/0/1')
+        api.switch_register_port('nexus', 'ethernet1/2')
+
+    def test_register_port_invalid_name_dell(self):
+        """Registering a port with an invalid name should fail"""
+
+        api.switch_register('dell', type=DELL,
+                            username="switch_user",
+                            password="switch_pass",
+                            hostname="switchname")
+
+        # test some random invalid port names for both delll switches
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('dell', 'blah-blah')
+
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('dell', 'gi1/0/1q')
+
+        with pytest.raises(api.BadArgumentError):
+            api.switch_register_port('dell', 'gi/0/1')
+
+        # register some valid port names
+        api.switch_register_port('dell', 'gi1/0/1')
+        api.switch_register_port('dell', 'te1/0/1')
+        api.switch_register_port('dell', 'gi2/1')
+        api.switch_register_port('dell', 'te1/12')


### PR DESCRIPTION
Issue #54 

Added a method to the switch class to check for well formed port names (simple pattern matching). This should prevent errors due to incorrect port names.

