### PR TITLE
API call to list HIL active extensions

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -1260,4 +1260,22 @@ Request Body:
 
 {}
 
+Response Body:
+
+[
+    [
+        "hil.ext.switches.mock",
+        ""
+    ],
+    [
+        "hil.ext.network_allocators.null",
+        ""
+    ],
+    ...
+]
+
 List all active extensions.
+
+Authorization requirements:
+
+* Administrative access.

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -1251,3 +1251,13 @@ Remove a user from a project.
 Authorization requirements:
 
 * Administrative access.
+
+#### list_active_extensions
+
+`GET /active_extensions`
+
+Request Body:
+
+{}
+
+List all active extensions.

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -1256,21 +1256,11 @@ Authorization requirements:
 
 `GET /active_extensions`
 
-Request Body:
-
-{}
-
 Response Body:
 
 [
-    [
-        "hil.ext.switches.mock",
-        ""
-    ],
-    [
-        "hil.ext.network_allocators.null",
-        ""
-    ],
+    "hil.ext.switches.mock",
+    "hil.ext.network_allocators.null",
     ...
 ]
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -1227,6 +1227,15 @@ def list_headnode_images():
     return json.dumps(valid_imgs)
 
 
+# Extension code #
+#################
+@rest_call('GET', '/active_extensions', Schema({}))
+def list_active_extensions():
+    """List all active extensions"""
+    extensions = cfg.items('extensions')
+    return json.dumps(extensions)
+
+
 # Console code #
 ################
 @rest_call('GET', '/node/<nodename>/console', Schema({'nodename': basestring}))

--- a/hil/api.py
+++ b/hil/api.py
@@ -1233,8 +1233,7 @@ def list_headnode_images():
 def list_active_extensions():
     """List all active extensions"""
     get_auth_backend().require_admin()
-    extensions_raw = cfg.items('extensions')
-    extensions = sorted([ext[0] for ext in extensions_raw])
+    extensions = [ext[0] for ext in cfg.items('extensions')]
     return json.dumps(extensions)
 
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -1234,7 +1234,7 @@ def list_active_extensions():
     """List all active extensions"""
     get_auth_backend().require_admin()
     extensions_raw = cfg.items('extensions')
-    extensions = [ext[0] for ext in extensions_raw]
+    extensions = sorted([ext[0] for ext in extensions_raw])
     return json.dumps(extensions)
 
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -1233,7 +1233,8 @@ def list_headnode_images():
 def list_active_extensions():
     """List all active extensions"""
     get_auth_backend().require_admin()
-    extensions = cfg.items('extensions')
+    extensions_raw = cfg.items('extensions')
+    extensions = [ext[0] for ext in extensions_raw]
     return json.dumps(extensions)
 
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -1232,6 +1232,7 @@ def list_headnode_images():
 @rest_call('GET', '/active_extensions', Schema({}))
 def list_active_extensions():
     """List all active extensions"""
+    get_auth_backend().require_admin()
     extensions = cfg.items('extensions')
     return json.dumps(extensions)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -1233,7 +1233,7 @@ def list_headnode_images():
 def list_active_extensions():
     """List all active extensions"""
     get_auth_backend().require_admin()
-    extensions = [ext[0] for ext in cfg.items('extensions')]
+    extensions = sorted([ext[0] for ext in cfg.items('extensions')])
     return json.dumps(extensions)
 
 

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -797,24 +797,13 @@ def create_admin_user(username, password):
 
 
 @cmd
-def list_active_extensions(ext_type):
-    """List active extensions by type.
-
-    Default types: auth, obm, switches, network_allocators.
-
-    Use the 'all' argument to list all active extensions.
-    """
+def list_active_extensions():
+    """List active extensions by type. """
     if not config.cfg.has_section('extensions'):
         sys.exit("There are no active extensions.")
-
     all_extensions = C.extensions.list_active()
-    if ext_type == 'all':
-        active = [ext[0] for ext in all_extensions]
-        sys.stdout.write('All active extensions: ' + ', '.join(active) + '\n')
-    else:
-        active = [ext[0] for ext in all_extensions if ext_type in ext[0]]
-        sys.stdout.write('Active extensions of type %s: ' % ext_type)
-        sys.stdout.write(', '.join(active) + '\n')
+    for ext in all_extensions:
+        print ext
 
 
 @cmd

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -802,7 +802,7 @@ def list_active_extensions():
     all_extensions = C.extensions.list_active()
     if not all_extensions:
         print "No active extensions"
-    else: 
+    else:
         for ext in all_extensions:
             print ext
 

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -799,11 +799,12 @@ def create_admin_user(username, password):
 @cmd
 def list_active_extensions():
     """List active extensions by type. """
-    if not config.cfg.has_section('extensions'):
-        sys.exit("There are no active extensions.")
     all_extensions = C.extensions.list_active()
-    for ext in all_extensions:
-        print ext
+    if not all_extensions:
+        print "No active extensions"
+    else: 
+        for ext in all_extensions:
+            print ext
 
 
 @cmd

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -797,6 +797,27 @@ def create_admin_user(username, password):
 
 
 @cmd
+def list_active_extensions(ext_type):
+    """List active extensions by type.
+
+    Default types: auth, obm, switches, network_allocators.
+
+    Use the 'all' argument to list all active extensions.
+    """
+    if not config.cfg.has_section('extensions'):
+        sys.exit("There are no active extensions.")
+
+    all_extensions = C.extensions.list_active()
+    if ext_type == 'all':
+        active = [ext[0] for ext in all_extensions]
+        sys.stdout.write('All active extensions: ' + ', '.join(active) + '\n')
+    else:
+        active = [ext[0] for ext in all_extensions if ext_type in ext[0]]
+        sys.stdout.write('Active extensions of type %s: ' % ext_type)
+        sys.stdout.write(', '.join(active) + '\n')
+
+
+@cmd
 def help(*commands):
     """Display usage of all following <commands>, or of all commands if none
     are given

--- a/hil/client/client.py
+++ b/hil/client/client.py
@@ -4,6 +4,7 @@ from hil.client.switch import Switch
 from hil.client.switch import Port
 from hil.client.network import Network
 from hil.client.user import User
+from hil.client.extensions import Extensions
 import abc
 import requests
 
@@ -105,3 +106,4 @@ class Client(object):
         self.port = Port(self.endpoint, self.httpClient)
         self.network = Network(self.endpoint, self.httpClient)
         self.user = User(self.endpoint, self.httpClient)
+        self.extensions = Extensions(self.endpoint, self.httpClient)

--- a/hil/client/extensions.py
+++ b/hil/client/extensions.py
@@ -1,4 +1,4 @@
-from haas.client.base import ClientBase
+from hil.client.base import ClientBase
 
 
 class Extensions(ClientBase):

--- a/hil/client/extensions.py
+++ b/hil/client/extensions.py
@@ -1,0 +1,13 @@
+from haas.client.base import ClientBase
+
+
+class Extensions(ClientBase):
+    """Consists of calls to query and manipulate extension related
+
+    objects and relations/
+    """
+
+    def list_active(self):
+        """List all active extensions. """
+        url = self.object_url('active_extensions')
+        return self.check_response(self.httpClient.request("GET", url))

--- a/tests/unit/api/auth.py
+++ b/tests/unit/api/auth.py
@@ -643,6 +643,7 @@ admin_calls = [
     (api.node_set_metadata, ['free_node_0', 'EK', 'pk'], {}),
     (api.node_delete_metadata, ['runway_node_0', 'EK'], {}),
     (api.port_revert, ['stock_switch_0', 'free_node_0_port'], {}),
+    (api.list_active_extensions, [], {}),
 ]
 
 

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -2220,7 +2220,7 @@ class TestExtensions:
     def test_extension_list(self):
         result = json.loads(api.list_active_extensions())
         assert result == [
-            'hil.ext.auth.null'
+            'hil.ext.auth.null',
             'hil.ext.network_allocators.null',
             'hil.ext.obm.ipmi',
             'hil.ext.obm.mock',

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -2220,11 +2220,11 @@ class TestExtensions:
     def test_extension_list(self):
         result = json.loads(api.list_active_extensions())
         assert result == [
-            'hil.ext.switches.mock',
+            'hil.ext.auth.null'
+            'hil.ext.network_allocators.null',
             'hil.ext.obm.ipmi',
             'hil.ext.obm.mock',
-            'hil.ext.network_allocators.null',
-            'hil.ext.auth.null'
+            'hil.ext.switches.mock',
             ]
 
 

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -2212,6 +2212,22 @@ class TestFancyNetworkCreate:
             assert network.network_id == '35'
 
 
+class TestExtensions:
+    """
+    Test extension related API calls
+    """
+
+    def test_extension_list(self):
+        result = json.loads(api.list_active_extensions())
+        assert result == [
+            'hil.ext.switches.mock',
+            'hil.ext.obm.ipmi',
+            'hil.ext.obm.mock',
+            'hil.ext.network_allocators.null',
+            'hil.ext.auth.null'
+            ]
+
+
 class TestDryRun:
     """
     Test that api calls using functions with @no_dry_run behave reasonably.

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -723,3 +723,45 @@ class Test_network:
         C.network.revoke_access('proj-02', 'newnet03')
         with pytest.raises(FailedAPICallException):
             C.network.revoke_access('proj-02', 'newnet03')
+
+
+@pytest.mark.usefixtures("create_setup")
+class Test_extensions:
+    """ Test extension related client calls. """
+
+    def test_extension_list(self):
+        """ Test listing active extensions. """
+        assert C.extensions.list_active() == [
+                    [
+                        "hil.ext.auth.database",
+                        ""
+                    ],
+                    [
+                        "hil.ext.switches.mock",
+                        ""
+                    ],
+                    [
+                        "hil.ext.switches.nexus",
+                        ""
+                    ],
+                    [
+                        "hil.ext.switches.dell",
+                        ""
+                    ],
+                    [
+                        "hil.ext.switches.brocade",
+                        ""
+                    ],
+                    [
+                        "hil.ext.obm.mock",
+                        ""
+                    ],
+                    [
+                        "hil.ext.obm.ipmi",
+                        ""
+                    ],
+                    [
+                        "hil.ext.network_allocators.vlan_pool",
+                        ""
+                    ],
+                ]

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -733,11 +733,11 @@ class Test_extensions:
         """ Test listing active extensions. """
         assert C.extensions.list_active() == [
                     "hil.ext.auth.database",
+                    "hil.ext.network_allocators.vlan_pool",
+                    "hil.ext.obm.ipmi",
+                    "hil.ext.obm.mock",
+                    "hil.ext.switches.brocade",
+                    "hil.ext.switches.dell",
                     "hil.ext.switches.mock",
                     "hil.ext.switches.nexus",
-                    "hil.ext.switches.dell",
-                    "hil.ext.switches.brocade",
-                    "hil.ext.obm.mock",
-                    "hil.ext.obm.ipmi",
-                    "hil.ext.network_allocators.vlan_pool",
                 ]

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -732,36 +732,12 @@ class Test_extensions:
     def test_extension_list(self):
         """ Test listing active extensions. """
         assert C.extensions.list_active() == [
-                    [
-                        "hil.ext.auth.database",
-                        ""
-                    ],
-                    [
-                        "hil.ext.switches.mock",
-                        ""
-                    ],
-                    [
-                        "hil.ext.switches.nexus",
-                        ""
-                    ],
-                    [
-                        "hil.ext.switches.dell",
-                        ""
-                    ],
-                    [
-                        "hil.ext.switches.brocade",
-                        ""
-                    ],
-                    [
-                        "hil.ext.obm.mock",
-                        ""
-                    ],
-                    [
-                        "hil.ext.obm.ipmi",
-                        ""
-                    ],
-                    [
-                        "hil.ext.network_allocators.vlan_pool",
-                        ""
-                    ],
+                    "hil.ext.auth.database",
+                    "hil.ext.switches.mock",
+                    "hil.ext.switches.nexus",
+                    "hil.ext.switches.dell",
+                    "hil.ext.switches.brocade",
+                    "hil.ext.obm.mock",
+                    "hil.ext.obm.ipmi",
+                    "hil.ext.network_allocators.vlan_pool",
                 ]


### PR DESCRIPTION
- Addressing #529:
- API call returns all active extensions.
- CLI call accepts a string to narrow the results to a certain extension or group of extensions.
- For example, `hil list_active_extensions mock` will return only the mock extensions currently loaded.
- `hil list_active_extensions all` will return all active extensions. 