### PR TITLE
Modified vlan_pool network allocator to ensure VLAN IDs dont collide.

### DIFF
--- a/hil/api.py
+++ b/hil/api.py
@@ -798,13 +798,9 @@ def network_create(network, owner, access, net_id):
     # Allocate net_id, if requested
     if net_id == "":
         net_id = get_network_allocator().get_new_network_id()
-        if net_id is None:
-            raise AllocationError('No more networks')
         allocated = True
     else:
-        if not get_network_allocator().validate_network_id(net_id):
-            raise BadArgumentError("Invalid net_id")
-        allocated = False
+        allocated = get_network_allocator().validate_network_id(net_id)
 
     network = model.Network(owner, access, allocated, net_id, network)
     db.session.add(network)

--- a/hil/api.py
+++ b/hil/api.py
@@ -800,15 +800,12 @@ def network_create(network, owner, access, net_id):
         net_id = get_network_allocator().get_new_network_id()
         if net_id is None:
             raise AllocationError('No more networks')
-        allocated = True
     else:
         if not get_network_allocator().validate_network_id(net_id):
             raise BadArgumentError("Invalid net_id")
-        if not get_network_allocator().network_id_available(net_id):
-            raise AllocationError("Network ID is in use. Please choose a "
-                                  "different net_id")
-        allocated = get_network_allocator().is_network_id_in_pool(net_id)
+        get_network_allocator().claim_network_id(net_id)
 
+    allocated = get_network_allocator().is_network_id_in_pool(net_id)
     network = model.Network(owner, access, allocated, net_id, network)
     db.session.add(network)
     db.session.commit()

--- a/hil/api.py
+++ b/hil/api.py
@@ -798,9 +798,16 @@ def network_create(network, owner, access, net_id):
     # Allocate net_id, if requested
     if net_id == "":
         net_id = get_network_allocator().get_new_network_id()
+        if net_id is None:
+            raise AllocationError('No more networks')
         allocated = True
     else:
-        allocated = get_network_allocator().validate_network_id(net_id)
+        if not get_network_allocator().validate_network_id(net_id):
+            raise BadArgumentError("Invalid net_id")
+        if not get_network_allocator().network_id_available(net_id):
+            raise AllocationError("Network ID is in use. Please choose a "
+                                  "different net_id")
+        allocated = get_network_allocator().is_network_id_in_pool(net_id)
 
     network = model.Network(owner, access, allocated, net_id, network)
     db.session.add(network)

--- a/hil/ext/network_allocators/null.py
+++ b/hil/ext/network_allocators/null.py
@@ -46,6 +46,12 @@ class NullNetworkAllocator(NetworkAllocator):
     def validate_network_id(self, net_id):
         return True
 
+    def claim_network_id(self, net_id):
+        return
+
+    def is_network_id_in_pool(self, net_id):
+        return True
+
 
 def setup(*args, **kwargs):
     set_network_allocator(NullNetworkAllocator())

--- a/hil/ext/network_allocators/vlan_pool.py
+++ b/hil/ext/network_allocators/vlan_pool.py
@@ -5,6 +5,7 @@ import logging
 from hil.network_allocator import NetworkAllocator, set_network_allocator
 from hil.model import db
 from hil.config import cfg
+from hil.errors import BlockedError
 
 
 def get_vlan_list():
@@ -69,19 +70,20 @@ class VlanAllocator(NetworkAllocator):
         except ValueError:
             return False
 
-    def network_id_available(self, net_id):
+    def claim_network_id(self, net_id):
         vlan = Vlan.query.filter_by(vlan_no=net_id).first()
         if vlan and vlan.available:
             vlan.available = False
-            return True
+            return
         elif vlan and not vlan.available:
-            return False
+            raise BlockedError("Network ID is not available."
+                               " Please choose a different ID.")
         else:
-            return True
+            return
 
     def is_network_id_in_pool(self, net_id):
         vlan = Vlan.query.filter_by(vlan_no=net_id).first()
-        return True if vlan else False
+        return vlan is not None
 
 
 class Vlan(db.Model):

--- a/hil/ext/network_allocators/vlan_pool.py
+++ b/hil/ext/network_allocators/vlan_pool.py
@@ -72,14 +72,13 @@ class VlanAllocator(NetworkAllocator):
 
     def claim_network_id(self, net_id):
         vlan = Vlan.query.filter_by(vlan_no=net_id).first()
-        if vlan and vlan.available:
-            vlan.available = False
+        if vlan is None:
             return
-        elif vlan and not vlan.available:
+        elif vlan.available:
+            vlan.available = False
+        else:
             raise BlockedError("Network ID is not available."
                                " Please choose a different ID.")
-        else:
-            return
 
     def is_network_id_in_pool(self, net_id):
         vlan = Vlan.query.filter_by(vlan_no=net_id).first()

--- a/hil/network_allocator.py
+++ b/hil/network_allocator.py
@@ -79,6 +79,14 @@ class NetworkAllocator(object):
     def validate_network_id(self, net_id):
         """Check if net_id is a valid network id"""
 
+    @abstractmethod
+    def claim_network_id(self, net_id):
+        """Claim a network id when an admin creates a network"""
+
+    @abstractmethod
+    def is_network_id_in_pool(self, net_id):
+        """returns true if net_id is part of the allocation pool"""
+
 
 _network_allocator = None
 

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -31,10 +31,19 @@ PORTS = ['gi1/0/1', 'gi1/0/2', 'gi1/0/3', 'gi1/0/4', 'gi1/0/5']
 def configure():
     config_testsuite()
     config_merge({
+        'auth': {
+            'require_authentication': 'True',
+        },
         'extensions': {
+            'hil.ext.auth.null': '',
             'hil.ext.switches.mock': '',
             'hil.ext.obm.ipmi': '',
             'hil.ext.obm.mock': '',
+            'hil.ext.network_allocators.null': None,
+            'hil.ext.network_allocators.vlan_pool': '',
+        },
+        'hil.ext.network_allocators.vlan_pool': {
+            'vlans': '40-80',
         },
     })
     config.load_extensions()
@@ -2129,7 +2138,7 @@ class TestShowNetwork:
             'name': 'spiderwebs',
             'owner': 'anvil-nextgen',
             'access': ['anvil-nextgen'],
-            "channels": ["null"]
+            "channels": ["vlan/native", "vlan/40"]
         }
 
     def test_show_network_public(self):
@@ -2143,7 +2152,7 @@ class TestShowNetwork:
             'name': 'public-network',
             'owner': 'admin',
             'access': None,
-            'channels': ['null'],
+            'channels': ['vlan/native', 'vlan/432'],
         }
 
     def test_show_network_provider(self):
@@ -2158,7 +2167,7 @@ class TestShowNetwork:
             'name': 'spiderwebs',
             'owner': 'admin',
             'access': ['anvil-nextgen'],
-            'channels': ['null'],
+            'channels': ['vlan/native', 'vlan/451'],
         }
 
 

--- a/tests/unit/ext/network_allocators/vlan_pool.py
+++ b/tests/unit/ext/network_allocators/vlan_pool.py
@@ -88,7 +88,7 @@ class TestAdminCreatedNetworks():
 
         api.project_create('nuggets')
 
-        # create a project owned network and get it's network_id
+        # create a project owned network and get its network_id
         api.network_create('hammernet', 'nuggets', 'nuggets', '')
         network = api._must_find(model.Network, 'hammernet')
         net_id = int(network.network_id)


### PR DESCRIPTION
Issue #804 

* Raises AllocationError if an admin tries to make a network with a net_id
 from the pool that is already in use
* method validate_network_id returns a boolean if the net_id belongs to the
 allocation pool or not.
* it raises a BadArgumentError if the net_id is invalid i.e., greater than 4096
 or less than 1

I did not want to add more methods to the VlanAllocator, so decided to just modify `validate_network_id` because it was introduced only for  admin networks. Let me know if this seems like a reasonable approach to address #804. If yes, then I'll fix the tests that are broken atm and write some more tests. If not, any suggestions?