### PR TITLE
Make clientlib tests faster, simpler, and more robust.

### DIFF
--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -59,9 +59,6 @@ class FlaskHTTPClient(HTTPClient):
 
 http_client = FlaskHTTPClient()
 C = Client(ep, http_client)  # Initializing client library
-MOCK_SWITCH_TYPE = 'http://schema.massopencloud.org/haas/v0/switches/mock'
-OBM_TYPE_MOCK = 'http://schema.massopencloud.org/haas/v0/obm/mock'
-OBM_TYPE_IPMI = 'http://schema.massopencloud.org/haas/v0/obm/ipmi'
 
 
 fail_on_log_warnings = pytest.fixture(fail_on_log_warnings)


### PR DESCRIPTION
Turns out I was a little off re: where the slowdown was coming from; every request made in the populate_server() fixture was triggering a call to sha512_crypt.verify, which is (intentionally) very slow.

This patch mocks that out during the client tests, since we aren't actually testing that bit, but do need that backend loaded for some of the tests.

I also still went ahead with ripping out the HTTP server; some of the other benefits are described in the commit message.