### PR TITLE
Fixed retrieval of json error message

### DIFF
--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -45,4 +45,4 @@ class ClientBase(object):
                 return
         else:
             e = json.loads(response.content)
-            raise FailedAPICallException(e['msg'])
+            raise FailedAPICallException(e['error']['message'])

--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -45,4 +45,7 @@ class ClientBase(object):
                 return
         else:
             e = json.loads(response.content)
-            raise FailedAPICallException(e['error']['message'])
+            if e.keys()[0] == 'error':
+                raise FailedAPICallException(e['error']['message'])
+            else:
+                raise FailedAPICallException(e['msg'])


### PR DESCRIPTION
- In response to issue #819:
- Previously, keystone auth errors would leave: `Unexpected error: msg` rather than a good description.
- Error was due to the json not being parsed correctly.
- Now keystone auth errors leave `Error: The request you have made requires authentication.` instead.