### PR TITLE
* Added method `ensure_config_file_exists()` that exits if the config…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,5 @@ install:
   - sh -e ci/keystone/install.sh
 
 script:
-  - sh -e ci/pep8_tests.sh
-  - sh -e ci/pylint_tests.sh
-  - sh -e ci/run_unit_tests.sh
   - sh -e ci/apache/run_integration_tests.sh
-  - sh -e ci/keystone/run_integration_tests.sh
   - sh -e ci/deployment-mock-networks/run_integration_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,9 @@ install:
   - sh -e ci/keystone/install.sh
 
 script:
+  - sh -e ci/pep8_tests.sh
+  - sh -e ci/pylint_tests.sh
+  - sh -e ci/run_unit_tests.sh
   - sh -e ci/apache/run_integration_tests.sh
+  - sh -e ci/keystone/run_integration_tests.sh
   - sh -e ci/deployment-mock-networks/run_integration_tests.sh

--- a/docs/INSTALL-devel.rst
+++ b/docs/INSTALL-devel.rst
@@ -221,7 +221,8 @@ Configuring HIL
 -----------------
 
 Now the ``hil`` executable should be in your path. First, create a
-configuration file ``hil.cfg``. There are two examples for you to work from,
+configuration file ``hil.cfg`` because if it's not found then hil would refuse
+to run and exit. There are two examples for you to work from,
 ``examples/hil.cfg.dev-no-hardware``, which is oriented towards development,
 and ``examples/hil.cfg`` which is more production oriented. These config files
 are well commented; read them carefully.

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -94,9 +94,10 @@ hil.cfg
 --------
 
 HIL is configured with ``hil.cfg``. This file contains settings for both the
-CLI client and the server. Carefully read the ``hil.cfg*`` files in
-``examples/``, to understand and correctly set all of the options.  In
-particular, the following two fields in the ``headnode`` section are very
+CLI client and the server. If ``hil.cfg`` is not found, hil would refuse to run
+and exit. Carefully read the ``hil.cfg*`` files in ``examples/``,
+to understand and correctly set all of the options.  In particular,
+the following two fields in the ``headnode`` section are very
 important: ``trunk_nic`` must match your choice of trunk NIC in the "Networking
 - Bridges" instructions below; ``base_imgs`` must match the name of the base
 headnode libvirt instance created in the "Libvirt" instructions below.

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -179,6 +179,7 @@ def object_url(*args):
     # Prefer an environmental variable for getting the endpoint if available.
     url = os.environ.get('HIL_ENDPOINT')
     if url is None:
+        config.setup()
         url = cfg.get('client', 'endpoint')
 
     for arg in args:
@@ -227,6 +228,7 @@ def serve(port):
         sys.exit('Unxpected Error!!! \n %s' % e)
 
     """Start the HIL API server"""
+    config.setup()
     if cfg.has_option('devel', 'debug'):
         debug = cfg.getboolean('devel', 'debug')
     else:
@@ -245,6 +247,7 @@ def serve_networks():
     """Start the HIL networking server"""
     from hil import model, deferred
     from time import sleep
+    config.setup()
     server.init()
     server.register_drivers()
     server.validate_state()
@@ -787,6 +790,7 @@ def create_admin_user(username, password):
     have an initial admin, you can (and should) create additional users via
     the API.
     """
+    config.setup()
     if not config.cfg.has_option('extensions', 'hil.ext.auth.database'):
         sys.exit("'make_inital_admin' is only valid with the database auth"
                  " backend.")
@@ -832,7 +836,6 @@ def main():
     this function.
     """
     ensure_not_root()
-    config.setup()
 
     if len(sys.argv) < 2 or sys.argv[1] not in command_dict:
         # Display usage for all commands

--- a/hil/config.py
+++ b/hil/config.py
@@ -35,10 +35,11 @@ def load(filename='hil.cfg'):
     This must be called once at program startup; no configuration options will
     be available until then.
 
-    If the configuration file is not available, this function will simply load
-    an empty configuration (i.e. one with no options).
+    If the config file is not found, it will simply exit.
     """
-    cfg.read(filename)
+    opened_file = cfg.read(filename)
+    if filename not in opened_file:
+        sys.exit("Config file not found. Please create hil.cfg")
 
 
 def configure_logging():


### PR DESCRIPTION
… file is not found.
* Calling this function before the hil admin commands, `serve`,
`serve_networks`, and `create admin user`.

Fix #338 