### PR TITLE
Fix CI on master

### DIFF
--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -2244,7 +2244,7 @@ class TestExtensions:
         result = json.loads(api.list_active_extensions())
         assert result == [
             'hil.ext.auth.null',
-            'hil.ext.network_allocators.null',
+            'hil.ext.network_allocators.vlan_pool',
             'hil.ext.obm.ipmi',
             'hil.ext.obm.mock',
             'hil.ext.switches.mock',

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -686,7 +686,6 @@ class Test_network:
             C.network.revoke_access('proj-02', 'newnet03')
 
 
-@pytest.mark.usefixtures("create_setup")
 class Test_extensions:
     """ Test extension related client calls. """
 


### PR DESCRIPTION
The tests were failing because the 2 PRs (#823 and #827) were merged before @izhmash 's #820. And #820 didnt have the changes that were introduced in the tests by those PRs. 
