### PR TITLE
Production docs update

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -146,6 +146,16 @@ To enable the database backend, make sure the **[extensions]** section of
 
   hil.ext.auth.database =
 
+Keystone Backend
+^^^^^^^^^^^^^^^^
+
+To enable the Keystone backend, make sure the **[extensions]** section of
+``hil.cfg`` contains::
+
+  hil.ext.auth.keystone =
+
+Visit the `Keystone configuration guide <http://hil.readthedocs.io/en/latest/keystone-auth.html>`_ for more information.
+
 Null Backend
 ^^^^^^^^^^^^
 

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -154,7 +154,7 @@ To enable the Keystone backend, make sure the **[extensions]** section of
 
   hil.ext.auth.keystone =
 
-Visit the `Keystone configuration guide <http://hil.readthedocs.io/en/latest/keystone-auth.html>`_ for more information.
+Visit the `Keystone configuration guide <keystone-auth.html>`_ for more information.
 
 Null Backend
 ^^^^^^^^^^^^

--- a/docs/Install_configure_PostgreSQL_CENTOS7.md
+++ b/docs/Install_configure_PostgreSQL_CENTOS7.md
@@ -99,13 +99,9 @@ $ psql -c '\dg'
  postgres  | Superuser, Create role, Create DB, Replication | {}
 ```
 
-If you wish to delete the user, do the following:
-
-```
-$ sudo -u postgres dropuser hil
-```
-**Note**: Make sure that the database role you create corresponds to an existing system user. 
-eg. There has to be a system user `hil` to access database named `hil` as database role named `hil`.
+**Note**: It is recommended that the PostgreSQL role and database you create correspond to an existing system user. 
+eg. There should be a system user `hil` to access database named `hil` as database role named `hil`.
+Advanced user/roll/database configurations may not need to follow this rule.  More information is available in the [Database Roles and Privileges](https://www.postgresql.org/docs/9.0/static/user-manag.html) reference guide.
 
 
 **7. Create database hil owned by database role hil:**

--- a/docs/Install_configure_PostgreSQL_CENTOS7.md
+++ b/docs/Install_configure_PostgreSQL_CENTOS7.md
@@ -101,7 +101,7 @@ $ psql -c '\dg'
 
 **Note**: It is recommended that the PostgreSQL role and database you create correspond to an existing system user. 
 eg. There should be a system user `hil` to access database named `hil` as database role named `hil`.
-Advanced user/roll/database configurations may not need to follow this rule.  More information is available in the [Database Roles and Privileges](https://www.postgresql.org/docs/9.0/static/user-manag.html) reference guide.
+Advanced user/role/database configurations may not need to follow this rule.  More information is available in the [Database Roles and Privileges](https://www.postgresql.org/docs/9.0/static/user-manag.html) reference guide.
 
 
 **7. Create database hil owned by database role hil:**

--- a/docs/keystone-auth.md
+++ b/docs/keystone-auth.md
@@ -4,7 +4,7 @@ An authentication backend for Openstack's Keystone is maintained in this
 source tree as `hil.ext.auth.keystone`. This document describes its
 configuration and usage in detail.
 
-NOTE: The HIL command line interface only supports the keystone v3 API.
+NOTE: The HIL command line interface only supports the Keystone v3 API.
 The server supports anything supported by [keystonemiddleware][1].
 
 ## Usage
@@ -39,8 +39,8 @@ As with any other extension, you must load the extension in `hil.cfg`:
     [extensions]
     hil.ext.auth.keystone =
 
-The backend must then be configured to talk to your keystone server.
-The keystone project maintains documentation on how to do this at:
+The backend must then be configured to talk to your Keystone server.
+The Keystone project maintains documentation on how to do this at:
 
 <http://docs.openstack.org/developer/keystonemiddleware/middlewarearchitecture.html>
 
@@ -63,4 +63,4 @@ If a text token is returned, then authentication to OpenStack is working.
 Testing authentication directly to the HIL API is also helpful.
 Using the token from the tip above, run:
 ``curl -H 'x-auth-token: <token>' <HIL address>/nodes/free``.
-If the response lists the nodes in the current HIL setup, then the keystone middleware has been setup correctly. 
+If the response lists the nodes in the current HIL setup, then the Keystone middleware has been setup correctly. 


### PR DESCRIPTION
- Docs updated to remedy confusion from recent production installation.
- The line about dropping a user usually isn't relevant to a standard user.  If an inexperienced admin is following the guide closely, accidentally dropping the `HIL` user would cause issues.
- Postgres doesn't require all naming to be the same, it just helps setup defaults.
- Also included minor Keystone doc-related issues.