### PR TITLE
Native VLAN requirement and native VLAN presense port power relation

### DIFF
--- a/hil/api.py
+++ b/hil/api.py
@@ -454,7 +454,6 @@ def node_detach_network(node, nic, network):
     if attachment is None:
         raise BadArgumentError("The network is not attached to the nic.")
     # Check if any other VLANs are attached before removing the native VLAN
-    # FIXME: This returns true even if the network being removed isn't native
     if attachment.channel == 'vlan/native' \
         and db.session.query(model.NetworkAttachment) \
             .filter(model.NetworkAttachment.channel != 'vlan/native') \

--- a/hil/api.py
+++ b/hil/api.py
@@ -413,6 +413,7 @@ def node_connect_network(node, nic, network, channel=None):
     if channel != 'vlan/native' \
             and db.session.query(model.NetworkAttachment) \
             .filter(model.NetworkAttachment.channel == 'vlan/native') \
+            .filter(model.NetworkAttachment.nic_id == nic.id) \
             .count() < 1:
         raise BlockedError("Please attach a native VLAN first.")
 
@@ -1296,23 +1297,6 @@ def stop_console(nodename):
 
 # Helper functions #
 ####################
-def _get_count(cls):
-    """Returns the number of instances of a given object type.
-
-    Arguments:
-
-    cls - the class name of the object to query.
-    """
-    return db.session.query(cls).count()
-
-
-def _get_count_row(cls, col):
-    """Helper function to count column instances in a function."""
-    return db.session.query(cls) \
-        .filter(col != 'vlan/native') \
-        .count()
-
-
 def _assert_absent(cls, name):
     """Raises a DuplicateError if the given object is already in the database.
 

--- a/hil/ext/switches/_console.py
+++ b/hil/ext/switches/_console.py
@@ -87,7 +87,6 @@ class Session(object):
 
         self.enter_if_prompt(interface)
         self.console.expect(self.if_prompt)
-
         if channel == 'vlan/native':
             old_native = NetworkAttachment.query.filter_by(
                 channel='vlan/native',

--- a/hil/ext/switches/_console.py
+++ b/hil/ext/switches/_console.py
@@ -36,6 +36,13 @@ class Session(object):
         """Navigate back to the main prompt from an interface prompt."""
 
     @abstractmethod
+    def _port_on(self):
+        """Power on the current interface."""
+
+    def _port_off(self):
+        """Power off the current interface."""
+
+    @abstractmethod
     def enable_vlan(self, vlan_id):
         """Enable ``vlan_id`` for the current interface.
 
@@ -102,8 +109,10 @@ class Session(object):
                 "switch!"
             vlan_id = match.groups()[0]
             if network_id is None:
+                self._port_off()
                 self.disable_vlan(vlan_id)
             else:
+                self._port_on()
                 assert network_id == vlan_id
                 self.enable_vlan(vlan_id)
 
@@ -114,6 +123,7 @@ class Session(object):
         self.enter_if_prompt(port)
         self.console.expect(self.if_prompt)
 
+        self._port_off()
         self.disable_port()
 
         self.exit_if_prompt()

--- a/hil/ext/switches/_dell_base.py
+++ b/hil/ext/switches/_dell_base.py
@@ -32,6 +32,12 @@ class _BaseSession(_console.Session):
         self._sendline('exit')
         self._sendline('exit')
 
+    def _port_on(self):
+        self._sendline('no shutoff')
+
+    def _port_off(self):
+        self._sendline('shutoff')
+
     def enable_vlan(self, vlan_id):
         self._sendline('sw mode trunk')
         self._sendline('sw trunk allowed vlan add ' + vlan_id)

--- a/hil/ext/switches/_dell_base.py
+++ b/hil/ext/switches/_dell_base.py
@@ -32,11 +32,11 @@ class _BaseSession(_console.Session):
         self._sendline('exit')
         self._sendline('exit')
 
-    def _port_on(self):
-        self._sendline('no shutoff')
-
     def _port_off(self):
         self._sendline('shutoff')
+
+    def _port_on(self):
+        self._sendline('no shutoff')
 
     def enable_vlan(self, vlan_id):
         self._sendline('sw mode trunk')

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -190,6 +190,27 @@ class Brocade(Switch):
         except AttributeError:
             return []
 
+    def _port_off(self, interface):
+        """ Power off the selected interface.
+
+        Args:
+            interface: interface to power off
+        """
+        url = self._construct_url(interface)
+        payload = '<shutdown>true</shutdown>'
+        self._make_request('PUT', url, data=payload)
+
+
+    def _port_on(self, interface):
+        """ Power on the selected interface.
+
+        Args:
+            interface: interface to power on
+        """
+        url = self._construct_url(interface)
+        payload = '<shutdown>false</shutdown>'
+        self._make_request('PUT', url, data=payload)
+
     def _get_native_vlan(self, interface):
         """ Return the native vlan of an interface.
 

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -98,6 +98,12 @@ class _Session(_console.Session):
         self.console.sendline('exit')
         self.console.sendline('exit')
 
+    def _port_on(self):
+        self.console.sendline('no shutdown')
+
+    def _port_off(self):
+        self.console.sendline('shutdown')
+
     def enable_vlan(self, vlan_id):
         self.console.sendline('sw')
         self.console.sendline('sw mode trunk')

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -98,11 +98,11 @@ class _Session(_console.Session):
         self.console.sendline('exit')
         self.console.sendline('exit')
 
-    def _port_on(self):
-        self.console.sendline('no shutdown')
-
     def _port_off(self):
         self.console.sendline('shutdown')
+
+    def _port_on(self):
+        self.console.sendline('no shutdown')
 
     def enable_vlan(self, vlan_id):
         self.console.sendline('sw')


### PR DESCRIPTION
- In response to #846 and #847:
- API server now requires a native VLAN to exist if there are any trunked VLANs.
- When a port's native VLAN is removed from a switch port, the port powers off.
- When a port's native VLAN is created, the port powers on.
- This places direct port power out of the hands of the user.
- This PR is part of the solution to removing the dummy VLAN.
- Note: There are a few Travis errors that I'm aware of, but I wanted to put this out for review before going any further.