### PR TITLE
pylint: check for duplicate imports

### DIFF
--- a/ci/pylint_tests.sh
+++ b/ci/pylint_tests.sh
@@ -15,5 +15,6 @@ if [ -z "$DB" ] || [ "$DB" = sqlite ]; then
 	  --enable=arguments-differ \
 	  --enable=missing-docstring \
 	  --enable=logging-not-lazy \
+	  --enable=reimported \
 	  $(./ci/list_tracked_pyfiles.sh)
 fi

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -28,7 +28,6 @@ from hil.migrations import paths
 from hil.ext.switches import _console
 from hil.ext.switches._dell_base import _BaseSession
 from os.path import dirname, join
-from hil.migrations import paths
 from hil.errors import BadArgumentError
 from hil.model import BigIntegerType
 

--- a/tests/unit/class_resolver.py
+++ b/tests/unit/class_resolver.py
@@ -16,8 +16,8 @@ def mock_extensions():
     Just used for the side-effect of registering the subclasses.
     """
     # pylint: disable=unused-variable
-    from hil.ext.obm import mock
-    from hil.ext.switches import mock
+    import hil.ext.obm.mock
+    import hil.ext.switches.mock
 
 
 class Food(object):

--- a/tests/unit/migrations.py
+++ b/tests/unit/migrations.py
@@ -16,13 +16,14 @@ The general approach is as follows:
 
 """
 import pytest
-from hil import api, server
+from hil import api, model, server
 from hil.test_common import config_testsuite, config_merge, initial_db, \
     fail_on_log_warnings
 from hil.config import cfg, load_extensions
 from hil.model import db, init_db
 from hil.flaskapp import app
 from hil.migrations import create_db
+from hil.rest import local
 from flask_migrate import upgrade
 from os import path
 import re
@@ -70,8 +71,6 @@ def create_pending_actions_db():
 
 def create_bigint_db():
     """Create database objects used in 'after-PK-bigint.sql'"""
-    from hil import model
-    from hil.model import db
     from hil.ext.switches.n3000 import DellN3000
     from hil.ext.switches.dell import PowerConnect55xx
     from hil.ext.switches.brocade import Brocade
@@ -80,7 +79,6 @@ def create_bigint_db():
     from hil.ext.obm.ipmi import Ipmi
     from hil.ext.obm.mock import MockObm
     from hil.ext.auth.database import User
-    from hil.rest import local
     from hil.ext.auth import database as dbauth
     with app.app_context():
         db.session.add(DellN3000(label='sw-n3000',


### PR DESCRIPTION
Pylint was complaining about this in 3 places:

* A duplicate import of paths
* Arguably a false positive, we were importing two different mock
  drivers locally, for the side-effects only, under the same name.
  I changed these to import the modules fully-qualified, which satisfies
  pylint.
* hil.model.db was being imported locally in the migration tests, *in
  addition to* being imported at the top of the file. I removed the
  redundant local import. While there, I also moved some local imports
  of non-extensions to global scope, as these are safe to import at the
  top of the file.