### PR TITLE
Show network now shows node and nic connected to network

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -200,7 +200,7 @@ The result must contain the following fields:
 * "owner", the name of the project which created the network, or
   "admin", if it was created by an administrator.
 * "access", a list of projects that have access to the network or null if the network is public
-* "node, nic": node and nic connected to network
+* "connected-nics": nodes and list of nics connected to network
 
 Response body (on success):
 
@@ -209,7 +209,7 @@ Response body (on success):
         "channels": <chanel-id-list>,
         "owner": <project or "admin">,
         "access": <project(s) with access to the network/null>
-        "node, nic": <list of node, nic>
+        "connected-nodes": {"<node>": [<list of nics connected to network]}
     }
 
 Authorization requirements:
@@ -217,6 +217,8 @@ Authorization requirements:
 * If the network is public, no special access is required.
 * Otherwise, access to a project in the "access" list or
 administrative access is required.
+* Admin access to view all connected-nodes is required; otherwise only the
+nodes that a non-admin user has access to will be shown.
 
 #### Channel Formats
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -200,7 +200,7 @@ The result must contain the following fields:
 * "owner", the name of the project which created the network, or
   "admin", if it was created by an administrator.
 * "access", a list of projects that have access to the network or null if the network is public
-* "connected-nics": nodes and list of nics connected to network
+* "connected-nodes": nodes and list of nics connected to network
 
 Response body (on success):
 
@@ -217,8 +217,8 @@ Authorization requirements:
 * If the network is public, no special access is required.
 * Otherwise, access to a project in the "access" list or
 administrative access is required.
-* Admin access to view all connected-nodes is required; otherwise only the
-nodes that a non-admin user has access to will be shown.
+* Admins and network owners can see all nodes connected to network; other users
+only see connected nodes that they have access to.
 
 #### Channel Formats
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -200,6 +200,7 @@ The result must contain the following fields:
 * "owner", the name of the project which created the network, or
   "admin", if it was created by an administrator.
 * "access", a list of projects that have access to the network or null if the network is public
+* "node, nic": node and nic connected to network
 
 Response body (on success):
 
@@ -208,6 +209,7 @@ Response body (on success):
         "channels": <chanel-id-list>,
         "owner": <project or "admin">,
         "access": <project(s) with access to the network/null>
+        "node, nic": <list of node, nic>
     }
 
 Authorization requirements:

--- a/hil/api.py
+++ b/hil/api.py
@@ -380,7 +380,6 @@ def node_connect_network(node, nic, network, channel=None):
             model.NetworkAttachment.nic == nic,
             query,
         ).first() is not None
-
     auth_backend = get_auth_backend()
 
     node = _must_find(model.Node, node)
@@ -894,6 +893,9 @@ def show_network(network):
         result['access'] = [p.label for p in network.access]
     else:
         result['access'] = None
+
+    result['node, nic'] = [[n.nic.owner.label, n.nic.label]
+                           for n in network.attachments]
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -894,8 +894,15 @@ def show_network(network):
     else:
         result['access'] = None
 
-    result['node, nic'] = [[n.nic.owner.label, n.nic.label]
-                           for n in network.attachments]
+    if network.owner is None:
+        x = {}
+        for n in network.attachments:
+            if auth_backend.have_project_access(n.nic.owner.project):
+                x.update({n.nic.owner.label: n.nic.label})
+        result['connected-nodes'] = x
+    else:
+        result['connected-nodes'] = {n.nic.owner.label: n.nic.label
+                                     for n in network.attachments}
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -894,16 +894,17 @@ def show_network(network):
     else:
         result['access'] = None
 
-    x = {}
+    connected_nodes = {}
     for n in network.attachments:
-        if auth_backend.have_project_access(n.nic.owner.project):
+        if auth_backend.have_project_access(network.owner) or \
+                auth_backend.have_project_access(n.nic.owner.project):
             node, nic = n.nic.owner.label, n.nic.label
             # build a dictonary mapping a node to list of nics
-            if node not in x:
-                x[node] = [nic]
+            if node not in connected_nodes:
+                connected_nodes[node] = [nic]
             else:
-                x[node].append(nic)
-    result['connected-nodes'] = x
+                connected_nodes[node].append(nic)
+    result['connected-nodes'] = connected_nodes
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -894,15 +894,16 @@ def show_network(network):
     else:
         result['access'] = None
 
-    if network.owner is None:
-        x = {}
-        for n in network.attachments:
-            if auth_backend.have_project_access(n.nic.owner.project):
-                x.update({n.nic.owner.label: n.nic.label})
-        result['connected-nodes'] = x
-    else:
-        result['connected-nodes'] = {n.nic.owner.label: n.nic.label
-                                     for n in network.attachments}
+    x = {}
+    for n in network.attachments:
+        if auth_backend.have_project_access(n.nic.owner.project):
+            node, nic = n.nic.owner.label, n.nic.label
+            # build a dictonary mapping a node to list of nics
+            if node not in x:
+                x[node] = [nic]
+            else:
+                x[node].append(nic)
+    result['connected-nodes'] = x
 
     return json.dumps(result, sort_keys=True)
 

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -2446,7 +2446,7 @@ class TestShowNetwork:
             'owner': 'anvil-nextgen',
             'access': ['anvil-nextgen'],
             "channels": ["vlan/native", "vlan/40"],
-            'node, nic': [],
+            'connected-nodes': {},
         }
 
     def test_show_network_public(self):
@@ -2462,7 +2462,7 @@ class TestShowNetwork:
             'owner': 'admin',
             'access': None,
             'channels': ['vlan/native', 'vlan/432'],
-            'node, nic': [],
+            'connected-nodes': {},
         }
 
     def test_show_network_provider(self):
@@ -2479,7 +2479,7 @@ class TestShowNetwork:
             'owner': 'admin',
             'access': ['anvil-nextgen'],
             'channels': ['vlan/native', 'vlan/451'],
-            'node, nic': []
+            'connected-nodes': {},
         }
 
     def test_show_network_with_nodes(self, switchinit):
@@ -2498,7 +2498,7 @@ class TestShowNetwork:
             'owner': 'anvil-nextgen',
             'access': ['anvil-nextgen'],
             "channels": ["vlan/native", "vlan/40"],
-            'node, nic': [['node-london', 'eth0']],
+            'connected-nodes': {'node-london': ['eth0']},
         }
 
 

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -677,7 +677,7 @@ class Test_network:
                 u'channels': [u'vlan/native', u'vlan/1001'],
                 u'name': u'net-01',
                 u'owner': u'proj-01',
-                u'node, nic': [],
+                u'connected-nodes': {},
                 }
 
     def test_network_create(self):

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -676,7 +676,8 @@ class Test_network:
                 u'access': [u'proj-01'],
                 u'channels': [u'vlan/native', u'vlan/1001'],
                 u'name': u'net-01',
-                u'owner': u'proj-01'
+                u'owner': u'proj-01',
+                u'node, nic': [],
                 }
 
     def test_network_create(self):


### PR DESCRIPTION
* fixes #496 
* show_network will return a list of node,nic pairs that are connected to a
network. This is useful when a user wants to delete a network but can't delete it
because they don't know what nodes is the network connected to.

* added a small api test

* added a simple method in api tests, that can help reduce repepetitive code. 
* updated the REST API docs