### PR TITLE
Add revert port call in the client library

### DIFF
--- a/hil/cli.py
+++ b/hil/cli.py
@@ -660,8 +660,7 @@ def port_detach_nic(switch, port):
 @cmd
 def port_revert(switch, port):
     """Detach a <port> on a <switch> from all attached networks."""
-    url = object_url('switch', switch, 'port', port, 'revert')
-    do_post(url)
+    C.port.port_revert(switch, port)
 
 
 @cmd

--- a/hil/client/switch.py
+++ b/hil/client/switch.py
@@ -65,3 +65,8 @@ class Port(ClientBase):
         """Show what's connected to <port>"""
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("GET", url))
+
+    def port_revert(self, switch, port):
+        """removes all vlans from a switch port"""
+        url = self.object_url('switch', switch, 'port', port, 'revert')
+        return self.check_response(self.httpClient.request("POST", url))

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -577,6 +577,21 @@ class Test_port:
         with pytest.raises(FailedAPICallException):
             C.port.show('unknown-switch', 'unknown-port')
 
+    def test_port_revert(self):
+        """Revert port should run without error and remove all networks"""
+        C.node.connect_network('node-01', 'eth0', 'net-01', 'vlan/native')
+        deferred.apply_networking()
+        assert C.port.show('mock-01', 'gi1/0/1') == {
+                'node': 'node-01',
+                'nic': 'eth0',
+                'networks': {'vlan/native': 'net-01'}}
+        assert C.port.port_revert('mock-01', 'gi1/0/1') is None
+        deferred.apply_networking()
+        assert C.port.show('mock-01', 'gi1/0/1') == {
+                'node': 'node-01',
+                'nic': 'eth0',
+                'networks': {}}
+
 
 class Test_user:
     """ Tests user related client calls."""


### PR DESCRIPTION
* Also add a unit test for it

Realized that I had it only in one of my feature branches and we kinda need this for developing HIL client.