### PR TITLE
Add mechanism to handle switch capabilities

### DIFF
--- a/hil/ext/network_allocators/null.py
+++ b/hil/ext/network_allocators/null.py
@@ -52,6 +52,9 @@ class NullNetworkAllocator(NetworkAllocator):
     def is_network_id_in_pool(self, net_id):
         return True
 
+    def get_native_channel(self):
+        return "null"
+
 
 def setup(*args, **kwargs):
     """Register a NullNetworkAllocator as the network allocator."""

--- a/hil/ext/network_allocators/vlan_pool.py
+++ b/hil/ext/network_allocators/vlan_pool.py
@@ -90,6 +90,10 @@ class VlanAllocator(NetworkAllocator):
         vlan = Vlan.query.filter_by(vlan_no=net_id).one_or_none()
         return vlan is not None
 
+    def get_native_channel(self):
+        """Return the native channel"""
+        return "vlan/native"
+
 
 class Vlan(db.Model):
     """A VLAN for the Dell switch

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -50,6 +50,9 @@ class Brocade(Switch, SwitchSession):
     password = db.Column(db.String, nullable=False)
     interface_type = db.Column(db.String, nullable=False)
 
+    def get_capabilities():
+        return []
+
     @staticmethod
     def validate(kwargs):
         schema.Schema({

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -58,6 +58,9 @@ class PowerConnect55xx(Switch):
             'password': basestring,
         }).validate(kwargs)
 
+    def get_capabilities(self):
+        return ['native-network-not-required']
+
     def session(self):
         return _PowerConnect55xxSession.connect(self)
 

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -58,6 +58,9 @@ class DellNOS9(Switch, SwitchSession):
             'interface_type': basestring,
         }).validate(kwargs)
 
+    def get_capabilities(self):
+        return []
+
     def session(self):
         return self
 
@@ -81,6 +84,7 @@ class DellNOS9(Switch, SwitchSession):
         if channel == 'vlan/native':
             if new_network is None:
                 self._remove_native_vlan(interface)
+                self._port_shutdown(interface)
             else:
                 self._set_native_vlan(interface, new_network)
         else:
@@ -146,6 +150,8 @@ class DellNOS9(Switch, SwitchSession):
 
         Similar to _get_vlans()
         """
+        if not self._is_port_on(interface):
+            self._port_on(interface)
         response = self._get_port_info(interface)
         match = re.search(r'NativeVlanId:(\d+)\.', response)
         if match is not None:

--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -100,3 +100,6 @@ class MockSwitch(Switch, SwitchSession):
                 if net is not None:
                     ret[port].append((chan, net))
         return ret
+
+    def has_capability(self, name):
+        return True

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -52,7 +52,7 @@ class DellN3000(Switch):
     password = db.Column(db.String, nullable=False)
     dummy_vlan = db.Column(db.String, nullable=False)
 
-    def get_capabilities():
+    def get_capabilities(self):
         return ['native-network-not-required']
 
     @staticmethod

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -52,6 +52,9 @@ class DellN3000(Switch):
     password = db.Column(db.String, nullable=False)
     dummy_vlan = db.Column(db.String, nullable=False)
 
+    def get_capabilities():
+        return ['native-network-not-required']
+
     @staticmethod
     def validate(kwargs):
         schema.Schema({

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -51,7 +51,7 @@ class Nexus(Switch):
     password = db.Column(db.String, nullable=False)
     dummy_vlan = db.Column(db.String, nullable=False)
 
-    def get_capabilities():
+    def get_capabilities(self):
         return ['native-network-not-required']
 
     @staticmethod

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -51,6 +51,9 @@ class Nexus(Switch):
     password = db.Column(db.String, nullable=False)
     dummy_vlan = db.Column(db.String, nullable=False)
 
+    def get_capabilities():
+        return ['native-network-not-required']
+
     @staticmethod
     def validate(kwargs):
         schema.Schema({

--- a/hil/model.py
+++ b/hil/model.py
@@ -303,6 +303,14 @@ class SwitchSession(object):
         """
         assert False, "Subclasses MUST override get_port_networks"
 
+    def get_capabilities(self):
+        """ Returns a list of capabilities that a switch supports"""
+        return []
+
+    def has_capability(self, name):
+        """Returns a boolean indicating whether the switch supports <name>"""
+        return name in self.get_capabilities()
+
 
 class Obm(db.Model):
     """Obm superclass supporting various drivers

--- a/hil/model.py
+++ b/hil/model.py
@@ -246,6 +246,14 @@ class Switch(db.Model):
         and have ``session`` just return ``self``.
         """
 
+    def get_capabilities(self):
+        """ Returns a list of capabilities that a switch supports"""
+        return []
+
+    def has_capability(self, name):
+        """Returns a boolean indicating whether the switch supports <name>"""
+        return name in self.get_capabilities()
+
 
 class SwitchSession(object):
     """A session object for a switch.
@@ -302,14 +310,6 @@ class SwitchSession(object):
         This method is only for use by the test suite.
         """
         assert False, "Subclasses MUST override get_port_networks"
-
-    def get_capabilities(self):
-        """ Returns a list of capabilities that a switch supports"""
-        return []
-
-    def has_capability(self, name):
-        """Returns a boolean indicating whether the switch supports <name>"""
-        return name in self.get_capabilities()
 
 
 class Obm(db.Model):

--- a/hil/network_allocator.py
+++ b/hil/network_allocator.py
@@ -87,6 +87,10 @@ class NetworkAllocator(object):
     def is_network_id_in_pool(self, net_id):
         """returns true if net_id is part of the allocation pool"""
 
+    @abstractmethod
+    def get_native_channel(self):
+        """Return the native channel"""
+
 
 _network_allocator = None
 


### PR DESCRIPTION
* the first capability introduced here is the ability to have no native vlan for a trunk port.
* modified the network allocator backend to return a native network
* add checks in the api to to ensure that a native network is always set for a
switch that requires it
* modified all switch drivers except for brocade (that requires more work).
