### PR TITLE
Introduce a method in the switch drivers that check if an operation i…

### DIFF
--- a/docs/network-drivers.md
+++ b/docs/network-drivers.md
@@ -229,6 +229,9 @@ more valid interface types.
 The switch's API server either runs on port 8008 (HTTP) or 8888 (HTTPS), so be
 sure to specify that in the ``hostname``.
 
+This switch must have a native VLAN connected first before having any trunked
+VLANs. The switchport is turned on only when a native VLAN is connected.
+
 If you have multiple types of ports on the same switch, register the switch
 multiple times with different parameters for ``interface_type``.
 
@@ -246,6 +249,10 @@ The body of the api call request will look like:
 
 It accepts interface names the same way they would be accepted in the console
 of the switch, ex. ``1/3``.
+
+When a port is registered, ensure that it is turned off (otherwise it might be
+sitting on a default native vlan). HIL will then take care of turning on/off
+the port.
 
 ### Using multiple switches
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -463,7 +463,7 @@ def node_detach_network(node, nic, network):
             "The network is not attached to the nic.")
 
     switch = nic.port.owner
-    switch.ensure_legal_operation(nic, 'detach', None)
+    switch.ensure_legal_operation(nic, 'detach', attachment.channel)
 
     db.session.add(model.NetworkingAction(type='modify_port',
                                           nic=nic,

--- a/hil/api.py
+++ b/hil/api.py
@@ -420,6 +420,9 @@ def node_connect_network(node, nic, network, channel=None):
         raise errors.BadArgumentError(
             "Channel %r, is not legal for this network." % channel)
 
+    switch = nic.port.owner
+    switch.ensure_legal_operation(nic, 'connect', channel)
+
     db.session.add(model.NetworkingAction(type='modify_port',
                                           nic=nic,
                                           new_network=network,
@@ -458,6 +461,10 @@ def node_detach_network(node, nic, network):
     if attachment is None:
         raise errors.BadArgumentError(
             "The network is not attached to the nic.")
+
+    switch = nic.port.owner
+    switch.ensure_legal_operation(nic, 'detach', None)
+
     db.session.add(model.NetworkingAction(type='modify_port',
                                           nic=nic,
                                           channel=attachment.channel,

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -150,6 +150,8 @@ class DellNOS9(Switch, SwitchSession):
         # worked reliably in the first place) and then find our interface there
         # which is not feasible.
 
+        if not self._is_port_on(interface):
+            return []
         response = self._get_port_info(interface)
         # finds a comma separated list of integers starting with "T"
         match = re.search(r'T(\d+)((,\d+)?)*', response)
@@ -168,6 +170,8 @@ class DellNOS9(Switch, SwitchSession):
 
         Similar to _get_vlans()
         """
+        if not self._is_port_on(interface):
+            return None
         response = self._get_port_info(interface)
         match = re.search(r'NativeVlanId:(\d+)\.', response)
         if match is not None:
@@ -201,8 +205,6 @@ class DellNOS9(Switch, SwitchSession):
         \r\n\r\n Native Vlan Id: 1512.\r\n\r\n\r\n\r\n
         MOC-Dell-S3048-ON#</command>\n</output>\n"
         """
-        if not self._is_port_on(interface):
-            self._port_on(interface)
         command = 'interfaces switchport %s %s' % \
             (self.interface_type, interface)
         response = self._execute(interface, SHOW, command)

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -72,7 +72,7 @@ class DellNOS9(Switch, SwitchSession):
             # checks if it is trying to attach a trunked network, and then in
             # in the db see if nic does not have any networks attached natively
             raise BlockedError("Please attach a native network first")
-        elif channel is None and op_type == 'detach' and \
+        elif channel == 'vlan/native' and op_type == 'detach' and \
                 query.filter(table.channel != 'vlan/native').count() > 0:
             # if it is detaching a network, then check in the database if there
             # are any trunked vlans.

--- a/hil/model.py
+++ b/hil/model.py
@@ -246,6 +246,18 @@ class Switch(db.Model):
         and have ``session`` just return ``self``.
         """
 
+    def ensure_legal_operation(self, nic, op_type, channel):
+        """Checks with the switch if the operation is legal before queueing it.
+
+        channel is network channel
+        interface is Port object
+        op_type is type of operation (connect, detach)
+
+        Some drivers don't need this check at all. So the default behaviour is
+        to just return"""
+
+        return
+
 
 class SwitchSession(object):
     """A session object for a switch.

--- a/hil/model.py
+++ b/hil/model.py
@@ -250,7 +250,7 @@ class Switch(db.Model):
         """Checks with the switch if the operation is legal before queueing it.
 
         channel is network channel
-        interface is Port object
+        nic is Nic object
         op_type is type of operation (connect, detach)
 
         Some drivers don't need this check at all. So the default behaviour is

--- a/tests/unit/ext/switches/dellnos9.py
+++ b/tests/unit/ext/switches/dellnos9.py
@@ -1,0 +1,104 @@
+# Copyright 2016 Massachusetts Open Cloud Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS
+# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+"""Tests for the brocade switch driver"""
+
+import pytest
+
+from hil import model, api, config
+from hil.model import db
+from hil.test_common import config_testsuite, config_merge, fresh_database, \
+    fail_on_log_warnings, with_request_context, server_init, \
+    network_create_simple
+from hil.errors import BlockedError
+
+fail_on_log_warnings = pytest.fixture(autouse=True)(fail_on_log_warnings)
+fresh_database = pytest.fixture(fresh_database)
+server_init = pytest.fixture(server_init)
+with_request_context = pytest.yield_fixture(with_request_context)
+
+SWITCH_TYPE = 'http://schema.massopencloud.org/haas/v0/switches/dellnos9'
+
+
+@pytest.fixture
+def configure():
+    """Configure HIL"""
+    config_testsuite()
+    config_merge({
+        'auth': {
+            'require_authentication': 'True',
+        },
+        'extensions': {
+            'hil.ext.auth.null': '',
+            'hil.ext.switches.dellnos9': '',
+            'hil.ext.obm.mock': '',
+            'hil.ext.network_allocators.null': None,
+            'hil.ext.network_allocators.vlan_pool': '',
+        },
+        'hil.ext.network_allocators.vlan_pool': {
+            'vlans': '40-80',
+        },
+    })
+    config.load_extensions()
+
+
+default_fixtures = ['fail_on_log_warnings',
+                    'configure',
+                    'fresh_database',
+                    'server_init',
+                    'with_request_context']
+
+pytestmark = pytest.mark.usefixtures(*default_fixtures)
+
+
+def test_ensure_legal_operations():
+    """qweqweqwe"""
+
+    # create a project and a network
+    api.project_create('anvil-nextgen')
+    network_create_simple('hammernet', 'anvil-nextgen')
+
+    # register a switch of type dellnos9 and add a port to it
+    api.switch_register('s3048',
+                        type=SWITCH_TYPE,
+                        username="switch_user",
+                        password="switch_pass",
+                        hostname="switchname",
+                        interface_type="GigabitEthernet")
+    api.switch_register_port('s3048', '1/3')
+    switch = api._must_find(model.Switch, 's3048')
+
+    # register a ndoe and a nic
+    api.node_register('compute-01', obm={
+                  "type": "http://schema.massopencloud.org/haas/v0/obm/mock",
+                  "host": "ipmihost",
+                  "user": "root",
+                  "password": "tapeworm"})
+    api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
+    nic = api._must_find(model.Nic, 'eth0')
+
+    api.port_connect_nic('s3048', '1/3', 'compute-01', 'eth0')
+    network = api._must_find(model.Network, 'hammernet')
+
+    # connecting a trunked network wihtout having a native should fail
+    with pytest.raises(BlockedError):
+        switch.ensure_legal_operation(nic, 'connect', 'vlan/1212')
+
+    # put a trunked network in the database, and then try to remove native net
+    db.session.add(model.NetworkAttachment(
+                nic=nic,
+                network=network,
+                channel='vlan/1212'))
+
+    with pytest.raises(BlockedError):
+        switch.ensure_legal_operation(nic, 'detach', 'vlan/native')

--- a/tests/unit/ext/switches/dellnos9.py
+++ b/tests/unit/ext/switches/dellnos9.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Massachusetts Open Cloud Contributors
+# Copyright 2017 Massachusetts Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the
@@ -11,7 +11,7 @@
 # IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
-"""Tests for the brocade switch driver"""
+"""Unit tests for dell switches running Dell Networking OS 9 (with REST API)"""
 
 import pytest
 
@@ -62,7 +62,7 @@ pytestmark = pytest.mark.usefixtures(*default_fixtures)
 
 
 def test_ensure_legal_operations():
-    """qweqweqwe"""
+    """Test to ensure that ensure_legal_operations works as expected"""
 
     # create a project and a network
     api.project_create('anvil-nextgen')


### PR DESCRIPTION
…s legal

* this method is called by the API right before it queues any networking
action.

* for dell nos9 based switches, the checks ensures that a native network is
always attached first before any trunked vlans, and the native network is
also the last network to be removed.

* also turn off the port when revert_port is called.

* update get_port_info to turn on the port before querying it.