### PR TITLE
Get logging to work and add examples in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist
 /testsuite.cfg
 /site-layout.json
 /.cache
+hil.log

--- a/examples/hil.cfg
+++ b/examples/hil.cfg
@@ -14,7 +14,7 @@
 # logged.  Options include: debug, info, warn/warning, error, critical/fatal.
 log_level = debug
 
-# Set the directory for log file. Comment the line to disable logging to file.
+# Set the directory for the log file. Comment the line to disable logging to file.
 log_dir = /var/log/
 
 [auth]

--- a/examples/hil.cfg
+++ b/examples/hil.cfg
@@ -14,6 +14,9 @@
 # logged.  Options include: debug, info, warn/warning, error, critical/fatal.
 log_level = debug
 
+# Set the directory for log file. Comment the line to disable logging to file.
+log_dir = /var/log/
+
 [auth]
 # There are a handful of API calls that require no special access to execute.
 # By default, in this case the user must still successfully authenticate as
@@ -90,7 +93,7 @@ uri = sqlite:////absolute/path/to/hil.db
 #dry_run=
 
 [network-daemon]
-# The amount of time in seconds to sleep after attempting to empty the journal 
+# The amount of time in seconds to sleep after attempting to empty the journal
 # when running serve_networks. If set, must be > 0 and < 3600 (1 hour). A
 # warning will be logged if sleep_time is greater than 60 (1 minute).
 # Default value if unset is 2:

--- a/examples/hil.cfg.dev-no-hardware
+++ b/examples/hil.cfg.dev-no-hardware
@@ -4,6 +4,7 @@
 # below).
 [general]
 log_level = debug
+# log_dir = .
 
 [auth]
 require_authentication = False

--- a/hil/config.py
+++ b/hil/config.py
@@ -20,7 +20,7 @@ Once `load` has been called, it will be ready to use.
 """
 
 import ConfigParser
-import logging
+import logging.handlers
 import importlib
 import os
 import sys


### PR DESCRIPTION
* Logging wasn't working because `import logging` wouldn't import the
submodule `handlers`; so we explicitly do it.

* Also, it wasn't apparent how to set the path for the log file in
the config file, so added that.