### PR TITLE
Maintenance Pool Service

### DIFF
--- a/docs/maintenance-pool.md
+++ b/docs/maintenance-pool.md
@@ -14,7 +14,7 @@ frees the node from the maintenance pool with `hil project_detach_node`.
 
 ## Configuration
 
-The maintenance pool will be active if the `maintenance` section exists in hil.cfg
-and `enable` is set to True.  If so, `maintenance_project` must be set equal to the
+The maintenance pool will be active if the `maintenance` section exists in hil.cfg.
+If so, `maintenance_project` must be set equal to the
 name of the maintenance project registered in HIL and `url` must point at the maintenance
 service.

--- a/docs/maintenance-pool.md
+++ b/docs/maintenance-pool.md
@@ -1,0 +1,20 @@
+# Maintenance Pool
+
+## Overview
+
+The maintenance pool is an optional service implemented by server administrators
+that ideally performs extra operations on nodes after they have been removed from a project
+by `hil project_detach_node`. If enabled, HIL will move the node from its original project
+into the designated maintenance project.  Then, HIL will POST to the URL of the service with
+the name of the node.
+
+Maintenance service example: Once the POST is received, the maintenance service
+logs when the node was detached, wipes the disks, sets the boot device to PXE, and then
+frees the node from the maintenance pool with `hil project_detach_node`.
+
+## Configuration
+
+The maintenance pool will be active if the `maintenance` section exists in hil.cfg
+and `enable` is set to True.  If so, `maintenance_project` must be set equal to the
+name of the maintenance project registered in HIL and `url` must point at the maintenance
+service.

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -394,6 +394,11 @@ operation to be preformed. Each nic may have no more than one pending
 network operation; an attempt to queue a second action will result in an
 error.
 
+If a maintenance pool is configured, the maintenance service will be
+notified and the node will be moved into the maintenance project.
+Otherwise, the node will go directly to the free pool.
+Read `docs/maintenance-pool.md` for more information.
+
 Authorization requirements:
 
 * Access to the project to which `<node>` is assigned.

--- a/examples/hil.cfg
+++ b/examples/hil.cfg
@@ -105,7 +105,7 @@ uri = sqlite:////absolute/path/to/hil.db
 #
 # If ``shutdown`` is present, the node will power off before moving to
 # the maintenance pool.
-# shutdown = 
+# shutdown =
 
 
 [network-daemon]

--- a/examples/hil.cfg
+++ b/examples/hil.cfg
@@ -95,14 +95,17 @@ uri = sqlite:////absolute/path/to/hil.db
 [maintenance]
 # Options for configuring the maintenance pool.
 #
-# Enables maintenance pool functionality if True. Default is False:
-# enable = False
+# Maintenance pool is enabled if the project and the url exist.
 #
 # Name of the maintenance project:
 # maintenance_project = maintenance
 #
 # URL of maintenance pool service:
 # url = <service url>
+#
+# If ``shutdown`` is present, the node will power off before moving to
+# the maintenance pool.
+# shutdown = 
 
 
 [network-daemon]

--- a/examples/hil.cfg
+++ b/examples/hil.cfg
@@ -92,6 +92,19 @@ uri = sqlite:////absolute/path/to/hil.db
 # enabled:
 #dry_run=
 
+[maintenance]
+# Options for configuring the maintenance pool.
+#
+# Enables maintenance pool functionality if True. Default is False:
+# enable = False
+#
+# Name of the maintenance project:
+# maintenance_project = maintenance
+#
+# URL of maintenance pool service:
+# url = <service url>
+
+
 [network-daemon]
 # The amount of time in seconds to sleep after attempting to empty the journal
 # when running serve_networks. If set, must be > 0 and < 3600 (1 hour). A

--- a/hil/api.py
+++ b/hil/api.py
@@ -1395,6 +1395,8 @@ def _maintain(project, node, node_label):
         raise errors.NotFoundError("Maintenance URL not in hil.cfg.")
     elif (cfg.has_option('maintenance', 'url')):
         raise errors.NotFoundError("Maintenance project not in hil.cfg.")
+    else:
+        return
 
     if (cfg.has_option('maintenance', 'shutdown')):
         node.obm.power_off()

--- a/hil/api.py
+++ b/hil/api.py
@@ -121,7 +121,6 @@ def project_detach_node(project, node):
     """
     project = _must_find(model.Project, project)
     get_auth_backend().require_project_access(project)
-    node_label = node
     node = _must_find(model.Node, node)
     if node not in project.nodes:
         raise errors.NotFoundError("Node not in project")
@@ -137,7 +136,7 @@ def project_detach_node(project, node):
     node.obm.stop_console()
     node.obm.delete_console()
     project.nodes.remove(node)
-    _maintain(project, node, node_label)
+    _maintain(project, node, node.label)
     db.session.commit()
 
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -1402,6 +1402,6 @@ def _maintain(project, node, node_label):
     response = requests.post(url,
                              headers={'Content-Type': 'application/json'},
                              data=payload)
-    if (response.status_code > 400):
+    if (response.status_code >= 300):
         logger.warn('POST to maintenance service'
                     ' failed with response: %s', response.text)

--- a/hil/api.py
+++ b/hil/api.py
@@ -118,13 +118,11 @@ def project_detach_node(project, node):
 
     If the node has network attachments or pending network actions, a
     BlockedError will be raised.
-
-    If using a maintenance pool, please update the hil config accordingly.
     """
+    logger = logging.getLogger(__name__)
     project = _must_find(model.Project, project)
     get_auth_backend().require_project_access(project)
-    node_json = node
-    print(node_json)
+    node_label = node
     node = _must_find(model.Node, node)
     maintaining = False
     if node not in project.nodes:
@@ -137,27 +135,34 @@ def project_detach_node(project, node):
     for nic in node.nics:
         if nic.current_action is not None:
             raise errors.BlockedError("Node has pending network actions")
-    if (cfg.has_option('maintenance', 'enable') and
-            cfg.get('maintenance', 'enable')):
-        if (not cfg.has_option('maintenance', 'maintenance_project')):
-            raise errors.NotFoundError("Maintenance project not in hil.cfg.")
+
+    if (cfg.has_option('maintenance', 'maintenance_project') and
+            cfg.has_option('maintenance', 'url')):
         maintenance_proj = _must_find(
                 model.Project,
                 cfg.get('maintenance', 'maintenance_project')
                 )
         if (project != maintenance_proj):
             maintaining = True
-            if (not cfg.has_option('maintenance', 'url')):
-                raise errors.NotFoundError("Maintenance URL not in hil.cfg.")
-            else:
-                url = cfg.get('maintenance', 'url')
-            payload = json.dumps({'node': node_json})
+            url = cfg.get('maintenance', 'url')
+            payload = json.dumps({'node': node_label})
+    elif (cfg.has_option('maintenance', 'maintenance_project')):
+        raise errors.NotFoundError("Maintenance URL not in hil.cfg.")
+    elif (cfg.has_option('maintenance', 'url')):
+        raise errors.NotFoundError("Maintenance project not in hil.cfg.")
+
     node.obm.stop_console()
     node.obm.delete_console()
     project.nodes.remove(node)
     if (maintaining):
+        if (cfg.has_option('maintenance', 'shutdown')):
+            node.obm.power_off()
         maintenance_proj.nodes.append(node)
-        requests.post(url, data=payload)
+        response = requests.post(url, data=payload)
+        # Give warning if response > 400
+        if (response > 400):
+            logger.warn('POST to maintenance service' \
+                    ' failed with response: %s' % response)
     db.session.commit()
 
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -1399,9 +1399,13 @@ def _maintain(project, node, node_label):
     project.nodes.append(node)
     url = cfg.get('maintenance', 'url')
     payload = json.dumps({'node': node_label})
-    response = requests.post(url,
-                             headers={'Content-Type': 'application/json'},
-                             data=payload)
+    try:
+        response = requests.post(url,
+                                 headers={'Content-Type': 'application/json'},
+                                 data=payload)
+    except requests.ConnectionError:
+        logger.warn('POST to maintenance service'
+                    ' failed: connection failed')
     if (response.status_code >= 300):
         logger.warn('POST to maintenance service'
                     ' failed with response: %s', response.text)

--- a/hil/api.py
+++ b/hil/api.py
@@ -118,6 +118,8 @@ def project_detach_node(project, node):
 
     If the node has network attachments or pending network actions, a
     BlockedError will be raised.
+
+    If using a maintenance pool, please update the hil config accordingly.
     """
     project = _must_find(model.Project, project)
     get_auth_backend().require_project_access(project)
@@ -135,32 +137,27 @@ def project_detach_node(project, node):
     for nic in node.nics:
         if nic.current_action is not None:
             raise errors.BlockedError("Node has pending network actions")
-
-    if (cfg.has_option('maintenance', 'maintenance_project') and
-            cfg.has_option('maintenance', 'url')):
+    if (cfg.has_option('maintenance', 'enable') and
+            cfg.get('maintenance', 'enable')):
+        if (not cfg.has_option('maintenance', 'maintenance_project')):
+            raise errors.NotFoundError("Maintenance project not in hil.cfg.")
         maintenance_proj = _must_find(
                 model.Project,
                 cfg.get('maintenance', 'maintenance_project')
                 )
         if (project != maintenance_proj):
             maintaining = True
-    elif (cfg.has_option('maintenance', 'maintenance_project')):
-        raise errors.NotFoundError("Maintenance URL not in hil.cfg.")
-    elif (cfg.has_option('maintenance', 'url')):
-        raise errors.NotFoundError("Maintenance project not in hil.cfg.")
-
+            if (not cfg.has_option('maintenance', 'url')):
+                raise errors.NotFoundError("Maintenance URL not in hil.cfg.")
+            else:
+                url = cfg.get('maintenance', 'url')
+            payload = json.dumps({'node': node_json})
     node.obm.stop_console()
     node.obm.delete_console()
     project.nodes.remove(node)
-    maintenance_proj = _must_find(
-            model.Project,
-            cfg.get('maintenance', 'maintenance_project')
-            )
-    if (cfg.get('maintenance', 'enable') and project != maintenance_proj):
+    if (maintaining):
         maintenance_proj.nodes.append(node)
-        url = cfg.get('maintenance', 'url')
-        payload = json.dumps({'node': node_json})
-        request_status = requests.post(url, data=payload)
+        requests.post(url, data=payload)
     db.session.commit()
 
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -158,11 +158,12 @@ def project_detach_node(project, node):
         if (cfg.has_option('maintenance', 'shutdown')):
             node.obm.power_off()
         maintenance_proj.nodes.append(node)
-        response = requests.post(url, data=payload)
-        # Give warning if response > 400
-        if (response > 400):
-            logger.warn('POST to maintenance service' \
-                    ' failed with response: %s' % response)
+        response = requests.post(url,
+                                 headers={'Content-Type': 'application/json'},
+                                 data=payload)
+        if (response.status_code > 400):
+            logger.warn('POST to maintenance service'
+                        ' failed with response: %s' % response)
     db.session.commit()
 
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -121,7 +121,8 @@ def project_detach_node(project, node):
     """
     project = _must_find(model.Project, project)
     get_auth_backend().require_project_access(project)
-    node_label = node
+    node_json = node
+    print(node_json)
     node = _must_find(model.Node, node)
     maintaining = False
     if node not in project.nodes:
@@ -151,8 +152,15 @@ def project_detach_node(project, node):
     node.obm.stop_console()
     node.obm.delete_console()
     project.nodes.remove(node)
-    if (maintaining):
-        _maintain(maintenance_proj, node, node_label)
+    maintenance_proj = _must_find(
+            model.Project,
+            cfg.get('maintenance', 'maintenance_project')
+            )
+    if (cfg.get('maintenance', 'enable') and project != maintenance_proj):
+        maintenance_proj.nodes.append(node)
+        url = cfg.get('maintenance', 'url')
+        payload = json.dumps({'node': node_json})
+        request_status = requests.post(url, data=payload)
     db.session.commit()
 
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -119,7 +119,6 @@ def project_detach_node(project, node):
     If the node has network attachments or pending network actions, a
     BlockedError will be raised.
     """
-    logger = logging.getLogger(__name__)
     project = _must_find(model.Project, project)
     get_auth_backend().require_project_access(project)
     node_label = node
@@ -144,8 +143,6 @@ def project_detach_node(project, node):
                 )
         if (project != maintenance_proj):
             maintaining = True
-            url = cfg.get('maintenance', 'url')
-            payload = json.dumps({'node': node_label})
     elif (cfg.has_option('maintenance', 'maintenance_project')):
         raise errors.NotFoundError("Maintenance URL not in hil.cfg.")
     elif (cfg.has_option('maintenance', 'url')):
@@ -155,15 +152,7 @@ def project_detach_node(project, node):
     node.obm.delete_console()
     project.nodes.remove(node)
     if (maintaining):
-        if (cfg.has_option('maintenance', 'shutdown')):
-            node.obm.power_off()
-        maintenance_proj.nodes.append(node)
-        response = requests.post(url,
-                                 headers={'Content-Type': 'application/json'},
-                                 data=payload)
-        if (response.status_code > 400):
-            logger.warn('POST to maintenance service'
-                        ' failed with response: %s' % response)
+        _maintain(maintenance_proj, node, node_label)
     db.session.commit()
 
 

--- a/tests/unit/api/maintenance-pool.py
+++ b/tests/unit/api/maintenance-pool.py
@@ -6,10 +6,7 @@ from hil.test_common import config_testsuite, config_merge, fresh_database, \
 from hil.auth import get_auth_backend
 import pytest
 
-MOCK_SWITCH_TYPE = 'http://schema.massopencloud.org/haas/v0/switches/mock'
 OBM_TYPE_MOCK = 'http://schema.massopencloud.org/haas/v0/obm/mock'
-OBM_TYPE_IPMI = 'http://schema.massopencloud.org/haas/v0/obm/ipmi'
-PORTS = ['gi1/0/1', 'gi1/0/2', 'gi1/0/3', 'gi1/0/4', 'gi1/0/5']
 
 
 @pytest.fixture
@@ -53,17 +50,6 @@ with_request_context = pytest.yield_fixture(with_request_context)
 def set_admin_auth():
     """Set admin auth for all calls"""
     get_auth_backend().set_admin(True)
-
-
-@pytest.fixture
-def switchinit():
-    """Create a switch with one port"""
-    api.switch_register('sw0',
-                        type=MOCK_SWITCH_TYPE,
-                        username="switch_user",
-                        password="switch_pass",
-                        hostname="switchname")
-    api.switch_register_port('sw0', PORTS[2])
 
 
 @pytest.fixture

--- a/tests/unit/api/maintenance-pool.py
+++ b/tests/unit/api/maintenance-pool.py
@@ -31,7 +31,8 @@ def configure():
         },
         'maintenance': {
             'maintenance_project': 'maintenance',
-            'url': 'http://localhost/foo/bar'
+            # Keystone url acts as dummy for posting
+            'url': 'http://127.0.0.1:35357/v3/'
         }
     })
     config.load_extensions()


### PR DESCRIPTION
- If enabled and properly configured, `project_detach_node` will move the node to the maintenance project and POST to the maintenance service URL.
- `examples/hil.cfg` has been updated with the new config options.pool
- `docs/maintenance-pool` introduces the maintenance pool, shows an example use-case, and describes the configuration process.