### PR TITLE
Update _get_vlans to correctly gather all vlans.

### DIFF
--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -166,7 +166,7 @@ class DellNOS9(Switch, SwitchSession):
             if '-' in num_str:
                 num_str = num_str.split('-')
                 for x in range(int(num_str[0]), int(num_str[1])+1):
-                    vlan_list.append(x)
+                    vlan_list.append(str(x))
             else:
                 vlan_list.append(num_str)
 

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -153,11 +153,23 @@ class DellNOS9(Switch, SwitchSession):
         if not self._is_port_on(interface):
             return []
         response = self._get_port_info(interface)
-        # finds a comma separated list of integers starting with "T"
-        match = re.search(r'T(\d+)((,\d+)?)*', response)
+
+        # finds a comma separated list of integers and/or ranges starting with
+        # T. Sample T12,14-18,23,28,80-90 or T20 or T20,22 or T20-22
+        match = re.search(r'T(\d+(-\d+)?)(,\d+(-\d+)?)*', response)
         if match is None:
             return []
-        vlan_list = match.group().replace('T', '').split(',')
+        range_str = match.group().replace('T', '').split(',')
+        vlan_list = []
+        # need to interpret the ranges to numbers. e.g. 14-18 as 14,15,16,17,18
+        for num_str in range_str:
+            if '-' in num_str:
+                num_str = num_str.split('-')
+                for x in range(int(num_str[0]), int(num_str[1])+1):
+                    vlan_list.append(x)
+            else:
+                vlan_list.append(num_str)
+
         return [('vlan/%s' % x, x) for x in vlan_list]
 
     def _get_native_vlan(self, interface):
@@ -202,7 +214,7 @@ class DellNOS9(Switch, SwitchSession):
         G-GVRP tagged,M-Trunk\r\n i-Internal untagged, I-Internaltagged,
         v-VLTuntagged, V-VLTtagged\r\n\r\n Name:GigabitEthernet1/3\r\n 802.1Q
         Tagged:Hybrid\r\n Vlan membership:\r\n Q Vlans\r\n U 1512 \r\n T 1511
-        \r\n\r\n Native Vlan Id: 1512.\r\n\r\n\r\n\r\n
+        1612-1614,1700\r\n\r\n Native Vlan Id: 1512.\r\n\r\n\r\n\r\n
         MOC-Dell-S3048-ON#</command>\n</output>\n"
         """
         command = 'interfaces switchport %s %s' % \

--- a/tests/unit/ext/switches/dellnos9.py
+++ b/tests/unit/ext/switches/dellnos9.py
@@ -183,3 +183,5 @@ def test_get_vlans():
     assert switch._get_vlans('10-13') == [
         ('vlan/10', '10'), ('vlan/11', '11'),
         ('vlan/12', '12'), ('vlan/13', '13')]
+    # just in case if the switch returns a 2 vlan range.
+    assert switch._get_vlans('10-11') == [('vlan/10', '10'), ('vlan/11', '11')]

--- a/tests/unit/ext/switches/dellnos9.py
+++ b/tests/unit/ext/switches/dellnos9.py
@@ -21,7 +21,6 @@ from hil.test_common import config_testsuite, config_merge, fresh_database, \
     fail_on_log_warnings, with_request_context, server_init, \
     network_create_simple
 from hil.errors import BlockedError
-from hil.ext.switches.dellnos9 import DellNOS9
 
 fail_on_log_warnings = pytest.fixture(autouse=True)(fail_on_log_warnings)
 fresh_database = pytest.fixture(fresh_database)
@@ -148,13 +147,14 @@ def test_ensure_legal_operations():
 
 def test_get_vlans():
     """Check that _get_vlans correctly parses the response to grab all VLANs"""
+    from hil.ext.switches.dellnos9 import DellNOS9
 
     class MockDellNOS9(DellNOS9):
         """This class inherits from the DellNOS9 switch and then overrides
         some of the methods to return mock outputs. Makes it easier to write
         unit tests"""
 
-        def _get_port_info(self, vlans):
+        def _get_port_info(self, interface):
             """Returns mock port info"""
             ret = u"<outputxmlns='http://www.dell.com/ns/dell:0.1/root'>\n  \
             <command>show interfaces switchport GigabitEthernet1/3\r\n\r\n \
@@ -162,7 +162,7 @@ def test_get_vlans():
             G-GVRP tagged,M-Trunk\r\n i-Internal untagged, I-Internaltagged, \
             v-VLTuntagged, V-VLTtagged\r\n\r\n Name:GigabitEthernet1/3\r\n \
              802.1QTagged:Hybrid\r\n Vlan membership:\r\n Q Vlans\r\n U 1512 \
-             \r\n T " + vlans + "\r\n\r\n Native Vlan Id: 1512.\r\n\r\n \
+             \r\n T " + interface + "\r\n\r\n Native Vlan Id: 1512.\r\n\r\n \
             \r\n\r\nMOC-Dell-S3048-ON#</command>\n</output>\n"
             return ret.replace(' ', '')
 

--- a/tests/unit/ext/switches/dellnos9.py
+++ b/tests/unit/ext/switches/dellnos9.py
@@ -21,6 +21,7 @@ from hil.test_common import config_testsuite, config_merge, fresh_database, \
     fail_on_log_warnings, with_request_context, server_init, \
     network_create_simple
 from hil.errors import BlockedError
+from hil.ext.switches.dellnos9 import DellNOS9
 
 fail_on_log_warnings = pytest.fixture(autouse=True)(fail_on_log_warnings)
 fresh_database = pytest.fixture(fresh_database)
@@ -143,3 +144,42 @@ def test_ensure_legal_operations():
     api.node_detach_network('compute-01', 'eth0', 'hammernet')
     mock_networking_action()
     db.session.close()
+
+
+def test_get_vlans():
+    """Check that _get_vlans correctly parses the response to grab all VLANs"""
+
+    class MockDellNOS9(DellNOS9):
+        """This class inherits from the DellNOS9 switch and then overrides
+        some of the methods to return mock outputs. Makes it easier to write
+        unit tests"""
+
+        def _get_port_info(self, vlans):
+            """Returns mock port info"""
+            ret = u"<outputxmlns='http://www.dell.com/ns/dell:0.1/root'>\n  \
+            <command>show interfaces switchport GigabitEthernet1/3\r\n\r\n \
+            Codes: U-Untagged T-Tagged\r\n x-Dot1x untagged,X-Dot1xtagged\r\n \
+            G-GVRP tagged,M-Trunk\r\n i-Internal untagged, I-Internaltagged, \
+            v-VLTuntagged, V-VLTtagged\r\n\r\n Name:GigabitEthernet1/3\r\n \
+             802.1QTagged:Hybrid\r\n Vlan membership:\r\n Q Vlans\r\n U 1512 \
+             \r\n T " + vlans + "\r\n\r\n Native Vlan Id: 1512.\r\n\r\n \
+            \r\n\r\nMOC-Dell-S3048-ON#</command>\n</output>\n"
+            return ret.replace(' ', '')
+
+        def _is_port_on(self, port):
+            return True
+
+    # get a switch object
+    switch = MockDellNOS9()
+    # check that various combinations of tagged and untagged vlans are
+    # correctly parsed.
+    assert switch._get_native_vlan('mock-interface') == ('vlan/native', '1512')
+
+    assert switch._get_vlans('10') == [('vlan/10', '10')]
+    assert switch._get_vlans('10,20') == [('vlan/10', '10'), ('vlan/20', '20')]
+    assert switch._get_vlans('10, 20-23, 25') == [
+        ('vlan/10', '10'), ('vlan/20', '20'), ('vlan/21', '21'),
+        ('vlan/22', '22'), ('vlan/23', '23'), ('vlan/25', '25')]
+    assert switch._get_vlans('10-13') == [
+        ('vlan/10', '10'), ('vlan/11', '11'),
+        ('vlan/12', '12'), ('vlan/13', '13')]


### PR DESCRIPTION
The switch can return a range of vlans (e.g. 14-18). That needs to parsed
correctly to get all the VLANs.