### PR TITLE
update revert port in mock switch

### DIFF
--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -86,7 +86,8 @@ class MockSwitch(Switch, SwitchSession):
             state[port][channel] = new_network
 
     def revert_port(self, port):
-        del LOCAL_STATE[self.label][port]
+        if LOCAL_STATE[self.label][port]:
+            del LOCAL_STATE[self.label][port]
 
     def disconnect(self):
         pass


### PR DESCRIPTION
* check if the key value pair exists, before deleting it.
* without this, the switch would complain when you call revert_port on a port
with nothing attached to it.
* closes #860 