### PR TITLE
Save dellnos9 switch

### DIFF
--- a/examples/hil.cfg
+++ b/examples/hil.cfg
@@ -134,3 +134,6 @@ save = True
 # Same behaviour as the dell switch. Set `save` to False to stop the switch
 # from writing to flash memory.
 save = True
+
+[hil.ext.switches.dellnos9]
+save = True

--- a/hil/ext/switches/_dell_base.py
+++ b/hil/ext/switches/_dell_base.py
@@ -130,9 +130,7 @@ class _BaseSession(_console.Session):
         self.console.expect(['Copy succeeded', 'Configuration Saved'])
         logger.debug('Copy succeeded')
 
-    def _get_config(self, config_type):
-        """returns the requested configuration file from the switch"""
-
+    def get_config(self, config_type):
         self._set_terminal_lines('unlimited')
         self.console.expect(self.main_prompt)
         self._sendline('show ' + config_type + '-config')

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -214,7 +214,7 @@ class DellNOS9(Switch, SwitchSession):
         """
         command = 'interfaces switchport %s %s' % \
             (self.interface_type, interface)
-        response = self._execute(interface, SHOW, command)
+        response = self._execute(SHOW, command)
         return response.text.replace(' ', '')
 
     def _add_vlan_to_trunk(self, interface, vlan):
@@ -230,7 +230,7 @@ class DellNOS9(Switch, SwitchSession):
             self._port_on(interface)
         command = 'interface vlan ' + vlan + '\r\n tagged ' + \
             self.interface_type + ' ' + interface
-        self._execute(interface, CONFIG, command)
+        self._execute(CONFIG, command)
 
     def _remove_vlan_from_trunk(self, interface, vlan):
         """ Remove a vlan from a trunk port.
@@ -240,7 +240,7 @@ class DellNOS9(Switch, SwitchSession):
             vlan: vlan to remove
         """
         command = self._remove_vlan_command(interface, vlan)
-        self._execute(interface, CONFIG, command)
+        self._execute(CONFIG, command)
 
     def _remove_all_vlans_from_trunk(self, interface):
         """ Remove all vlan from a trunk port.
@@ -254,7 +254,7 @@ class DellNOS9(Switch, SwitchSession):
         # execute command only if there are some vlans to remove, otherwise
         # the switch complains
         if command is not '':
-            self._execute(interface, CONFIG, command)
+            self._execute(CONFIG, command)
 
     def _remove_vlan_command(self, interface, vlan):
         """Returns command to remove <vlan> from <interface>"""
@@ -274,7 +274,7 @@ class DellNOS9(Switch, SwitchSession):
             self._port_on(interface)
         command = 'interface vlan ' + vlan + '\r\n untagged ' + \
             self.interface_type + ' ' + interface
-        self._execute(interface, CONFIG, command)
+        self._execute(CONFIG, command)
 
     def _remove_native_vlan(self, interface):
         """ Remove the native vlan from an interface.
@@ -286,7 +286,7 @@ class DellNOS9(Switch, SwitchSession):
             vlan = self._get_native_vlan(interface)[1]
             command = 'interface vlan ' + vlan + '\r\n no untagged ' + \
                 self.interface_type + ' ' + interface
-            self._execute(interface, CONFIG, command)
+            self._execute(CONFIG, command)
         except TypeError:
             logger.error('No native vlan to remove')
 
@@ -335,7 +335,7 @@ class DellNOS9(Switch, SwitchSession):
 
     # HELPER METHODS *********************************************
 
-    def _execute(self, interface, command_type, command):
+    def _execute(self, command_type, command):
         """This method gets the url & the payload and executes <command>"""
         url = self._construct_url()
         payload = self._make_payload(command_type, command)

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -343,8 +343,7 @@ class DellNOS9(Switch, SwitchSession):
         command = 'write'
         self._execute(EXEC, command)
 
-    def _get_config(self, config_type):
-        """returns the requested configuration file from the switch"""
+    def get_config(self, config_type):
         command = config_type + '-config'
         config = self._execute(SHOW, command).text
 
@@ -369,12 +368,13 @@ class DellNOS9(Switch, SwitchSession):
         # stack-unit 1 provision S3048-ON
 
         lines_to_remove = 0
-        for line in config.splitlines():
+        lines = config.splitlines()
+        for line in lines:
             if 'username' in line:
                 break
             lines_to_remove += 1
 
-        config = config.split("\n", lines_to_remove)[lines_to_remove]
+        config = '\n'.join(lines[lines_to_remove:])
         # there were some extra spaces in one of the config file types that
         # would cause the tests to fail.
         return config.replace(" ", "")

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -393,10 +393,11 @@ class DellNOS9(Switch, SwitchSession):
         return self.username, self.password
 
     @staticmethod
-    def _make_payload(command, command_type):
+    def _make_payload(command_type, command):
         """Makes payload for passing CLI commands using the REST API"""
 
-        return '<input><%s>%s</%s></input>' % (command, command_type, command)
+        return '<input><%s>%s</%s></input>' % (command_type, command,
+                                               command_type)
 
     @staticmethod
     def _construct_tag(name):

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -233,9 +233,7 @@ class _Session(_console.Session):
         self.console.expect('Copy complete')
         logger.debug('Copy succeeded')
 
-    def _get_config(self, config_type):
-        """returns the requested configuration file from the switch"""
-
+    def get_config(self, config_type):
         self._set_terminal_lines('unlimited')
         self.console.expect(r'[\r\n]+.+# ')
         self._sendline('show ' + config_type + '-config')

--- a/hil/model.py
+++ b/hil/model.py
@@ -324,6 +324,17 @@ class SwitchSession(object):
         """saves the running config to startup config"""
         assert False, "Subclasses MUST override save_running_config"
 
+    def get_config(self, config_type):
+        """Returns the requested configuration file from the switch.
+
+        `config_type` is the configuration type. It can be `running` or
+        'startup'.
+
+        This method is only for use by the test suite.
+        """
+
+        assert False, "Subclasses MUST override save_running_config"
+
 
 class Obm(db.Model):
     """Obm superclass supporting various drivers

--- a/hil/model.py
+++ b/hil/model.py
@@ -320,6 +320,10 @@ class SwitchSession(object):
         """
         assert False, "Subclasses MUST override get_port_networks"
 
+    def save_running_config(self):
+        """saves the running config to startup config"""
+        assert False, "Subclasses MUST override save_running_config"
+
 
 class Obm(db.Model):
     """Obm superclass supporting various drivers

--- a/tests/deployment/switch_config.py
+++ b/tests/deployment/switch_config.py
@@ -27,9 +27,7 @@ from hil.test_common import config, config_testsuite, fresh_database, \
 import pytest
 import json
 
-DELL5500 = 'http://schema.massopencloud.org/haas/v0/switches/powerconnect55xx'
-NEXUS = 'http://schema.massopencloud.org/haas/v0/switches/nexus'
-DELLN3000 = 'http://schema.massopencloud.org/haas/v0/switches/delln3000'
+BROCADE = 'http://schema.massopencloud.org/haas/v0/switches/brocade'
 
 
 @pytest.fixture
@@ -44,6 +42,9 @@ def configure():
             'save': 'True'
         },
         'hil.ext.switches.n3000': {
+            'save': 'True'
+        },
+        'hil.ext.switches.dellnos9': {
             'save': 'True'
         }
     })
@@ -67,22 +68,19 @@ pytestmark = pytest.mark.usefixtures('configure',
 
 
 @pytest.fixture
-def not_dell_or_nexus():
-    """open the site-layout file to see if we don't have a dell or cisco nexus
-    switch"""
+def is_brocade():
+    """open the site-layout file to see if we have a brocade switch"""
 
     with open('site-layout.json') as layout_data:
         layout = json.load(layout_data)
     switch_type = layout['switches'][0]['type']
-    return (switch_type != NEXUS and switch_type != DELL5500 and
-            switch_type != DELLN3000)
+    return (switch_type == BROCADE)
 
 
-@pytest.mark.skipif(not_dell_or_nexus(),
-                    reason="Skipping because not a dell or cisco switch")
+@pytest.mark.skipif(is_brocade(), reason="Skipping because brocade switch")
 class TestSwitchSavingToFlash(NetworkTest):
-    """ saves the running config to the flash memory. Test is only for the dell
-        switch"""
+    """ saves the running config to the flash memory and tests if it succeeded
+    by comparing the running and startup config files"""
 
     def get_config(self, config_type):
         """returns the switch configuration file"""

--- a/tests/deployment/switch_config.py
+++ b/tests/deployment/switch_config.py
@@ -83,11 +83,13 @@ class TestSwitchSavingToFlash(NetworkTest):
     by comparing the running and startup config files"""
 
     def get_config(self, config_type):
-        """returns the switch configuration file"""
+        """helper method to get the switch config file by calling
+        the switch's get_config method
+        """
 
         switch = model.Switch.query.one()
         session = switch.session()
-        config = session._get_config(config_type)
+        config = session.get_config(config_type)
         session.disconnect()
         return config
 

--- a/tests/deployment/switch_config.py
+++ b/tests/deployment/switch_config.py
@@ -84,7 +84,7 @@ class TestSwitchSavingToFlash(NetworkTest):
 
     def get_config(self, config_type):
         """helper method to get the switch config file by calling
-        the switch's get_config method
+        SwitchSession's get_config()
         """
 
         switch = model.Switch.query.one()


### PR DESCRIPTION
Enable saving the switch configuration file to flash memory for the dell s3048-on switch/.
And there are some minor changes in the driver itself, but it's all in different commits. 

Will do the same for the brocade switch in a different PR.

Please scrutinize my PRs real hard, I have tried to be really careful but still miss out on some details. 

Also, will probably want to rebase after other switch related PRs are merged.
