### PR TITLE
Support Public key authentication to connect to switches

### DIFF
--- a/docs/network-drivers.md
+++ b/docs/network-drivers.md
@@ -92,6 +92,9 @@ following switch capabilities:
 no native networks in trunk mode. If not supported, then the switchport must be
 first connected to a native network before adding any tagged VLANs.
 
+* There should be **no "enable" password** for switch users which will be used
+by HIL.
+
 
 Per the information in `rest_api.md`, the details of certain API calls are
 driver-dependant, below are the details for each of these switches.
@@ -199,7 +202,6 @@ The body of the api call request can then look like:
         "dummy_vlan": 2222
     }
 
-* There should be no "enable" password.
 
 * If you choose to login using the public key, then provide any string as the
 password. Also, the user running the HIL network daemon should have access to the

--- a/docs/network-drivers.md
+++ b/docs/network-drivers.md
@@ -195,6 +195,13 @@ The body of the api call request can then look like:
         "dummy_vlan": 2222
     }
 
+* There should be no "enable" password.
+
+* If you choose to login using the public key, then provide any string as the
+password. Also, the user running the HIL network daemon should have access to the
+private key.
+
+
 #### switch_register_port
 
 Like the powerconnect driver, the Nexus driver accepts port names of the

--- a/docs/network-drivers.md
+++ b/docs/network-drivers.md
@@ -109,6 +109,10 @@ A few commands are necessary to run on the switch before it can be used with HIL
 
 2. This switch uses ssh for connection. Be sure that ssh is enabled on the switch.
 
+3. If you choose to login using the public key, then provide any string as the
+password. The user running the HIL network daemon should have access to the
+private key.
+
 #### switch_register
 
 To register a Dell Powerconnect switch, the ``"type"`` field of the

--- a/hil/ext/switches/_console.py
+++ b/hil/ext/switches/_console.py
@@ -178,3 +178,25 @@ def get_prompts(console):
             'if_prompt': re.escape(cmd_prompt[:-1]) + '\(config\\-if[^)]*\)#',
             'main_prompt': re.escape(cmd_prompt),
         }
+
+
+def login(switch):
+    """login to switch using either a password or key."""
+
+    alternatives = ['User Name:', '[Pp]assword:*', '>', '#']
+    console = pexpect.spawn(
+            'ssh ' + switch.username + '@' + switch.hostname)
+
+    outcome = console.expect(alternatives)
+    if outcome == 0:
+        # some switches, like the dell powerconnect, ask for the username again
+        console.sendline(switch.username)
+        outcome = console.expect(alternatives)
+    if outcome == 1:
+        console.sendline(switch.password)
+        outcome = console.expect(alternatives)
+    if outcome == 2:
+        console.sendline('enable')
+
+    logger.debug('Logged in to switch %r', switch)
+    return console

--- a/hil/ext/switches/_console.py
+++ b/hil/ext/switches/_console.py
@@ -181,7 +181,10 @@ def get_prompts(console):
 
 
 def login(switch):
-    """login to switch using either a password or key."""
+    """Login to switch using either a password or key.
+
+    `switch` must have the attributes, `username` and `password`.
+    """
 
     alternatives = ['User Name:', '[Pp]assword:*', '>', '#']
     console = pexpect.spawn(

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -93,22 +93,7 @@ class _PowerConnect55xxSession(_BaseSession):
     def connect(switch):
         """connect to the switch, and log in."""
 
-        console = pexpect.spawn(
-            'ssh ' + switch.username + '@' + switch.hostname)
-
-        # dell switch gets user name for the second time
-        console.expect('User Name:')
-        console.sendline(switch.username)
-
-        alternatives = ['[Pp]assword:', '>', '#']
-        outcome = console.expect(alternatives)
-        if outcome == 0:
-            console.sendline(switch.password)
-            outcome = console.expect(alternatives)
-        if outcome == 1:
-            console.sendline('enable')
-
-        logger.debug('Logged in to switch %r', switch)
+        console = _console.login(switch)
 
         # FIXME: There ought to be a better solution to get the prompts.
         # Send some string, so we expect the prompt again. Sending only new a

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -94,11 +94,12 @@ class _PowerConnect55xxSession(_BaseSession):
 
         console = _console.login(switch)
 
-        # FIXME: There ought to be a better solution to get the prompts.
         # Send some string, so we expect the prompt again. Sending only new a
-        # line doesn't work. Otherwise, we have some weird characters:
-        # Eg; if_prompt looks like '\\\x1b\\[Kconsole\\(config\\-if[^)]*\\)#'
-        # Don't know where "\\\x1b\\[K" comes from.
+        # line doesn't work, it returns some unwanted ANSI sequences in
+        # console.after
+        # Eg; main_prompts looks like '\r\n\r\r\x1b[Kconsole#'
+        # Here \x1b[K is unwanted and causes trouble parsing it.
+        # Sending some other random string doesn't have this issue.
         console.sendline('some-unrecognized-command')
         prompts = _console.get_prompts(console)
         return _PowerConnect55xxSession(switch=switch,

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -17,7 +17,6 @@ Currently the driver uses telnet to connect to the switch's console; in
 the long term we want to be using SNMP.
 """
 
-import pexpect
 import logging
 import schema
 import re

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -95,15 +95,27 @@ class _PowerConnect55xxSession(_BaseSession):
 
         console = pexpect.spawn(
             'ssh ' + switch.username + '@' + switch.hostname)
-        # dell switch gets user name for the second time
 
+        # dell switch gets user name for the second time
         console.expect('User Name:')
         console.sendline(switch.username)
-        console.expect('Password:')
-        console.sendline(switch.password)
+
+        alternatives = ['[Pp]assword:', '>', '#']
+        outcome = console.expect(alternatives)
+        if outcome == 0:
+            console.sendline(switch.password)
+            outcome = console.expect(alternatives)
+        if outcome == 1:
+            console.sendline('enable')
 
         logger.debug('Logged in to switch %r', switch)
 
+        # FIXME: There ought to be a better solution to get the prompts.
+        # Send some string, so we expect the prompt again. Sending only new a
+        # line doesn't work. Otherwise, we have some weird characters:
+        # Eg; if_prompt looks like '\\\x1b\\[Kconsole\\(config\\-if[^)]*\\)#'
+        # Don't know where "\\\x1b\\[K" comes from.
+        console.sendline('some-unrecognized-command')
         prompts = _console.get_prompts(console)
         return _PowerConnect55xxSession(switch=switch,
                                         console=console,

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -102,7 +102,10 @@ class _DellN3000Session(_BaseSession):
 
     @staticmethod
     def connect(switch):
-        """connect to the switch and log in"""
+        """Connect to the switch and log in.
+
+        Login using public key is untested on this switch.
+        """
         console = _console.login(switch)
 
         # send a new line so that we can "expect" a prompt again if we already

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -104,6 +104,10 @@ class _DellN3000Session(_BaseSession):
     def connect(switch):
         """connect to the switch and log in"""
         console = _console.login(switch)
+
+        # send a new line so that we can "expect" a prompt again if we already
+        # matched when logged in using pubkey
+        console.sendline('')
         prompts = _console.get_prompts(console)
 
         # create the dummy vlan for port_revert

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -18,7 +18,6 @@ Currently the driver uses telnet to connect to the switch's console; in
 the long term we want to be using SNMP.
 """
 
-import pexpect
 import re
 import logging
 import schema

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -104,16 +104,9 @@ class _DellN3000Session(_BaseSession):
     @staticmethod
     def connect(switch):
         """connect to the switch and log in"""
-        console = pexpect.spawn(
-            'ssh ' + switch.username + '@' + switch.hostname)
-
-        console.expect('password: ')
-        console.sendline(switch.password)
-        console.expect('>')
-        console.sendline('enable')
-
-        logger.debug('Logged in to switch %r', switch)
+        console = _console.login(switch)
         prompts = _console.get_prompts(console)
+
         # create the dummy vlan for port_revert
         # this is a one time thing though; maybe we could remove this and let
         # the admin create the dummy vlan on the switch

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -127,7 +127,7 @@ class _Session(_console.Session):
         console = _console.login(switch)
 
         # send a new line so that we can "expect" a prompt again if we already
-        # matched when outcome was 2 (pub key auth)
+        # matched when logged in using pubkey
         console.sendline('')
         prompts = _console.get_prompts(console)
 

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -124,12 +124,22 @@ class _Session(_console.Session):
     @staticmethod
     def connect(switch):
         """Connect to the switch."""
+        alternatives = ['[Pp]assword: ', '>', '#']
         console = pexpect.spawn(
             'ssh ' + switch.username + '@' + switch.hostname)
 
-        console.expect('Password: ')
-        console.sendline(switch.password)
+        outcome = console.expect(alternatives)
+        if outcome == 0:
+            console.sendline(switch.password)
+            outcome = console.expect(alternatives)
+        if outcome == 1:
+            console.sendline('en')
 
+        logger.debug('Logged in to switch %r', switch)
+
+        # send a new line so that we can "expect" a prompt again if we already
+        # matched when outcome was 2 (pub key auth)
+        console.sendline('')
         prompts = _console.get_prompts(console)
 
         return _Session(console=console,

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -124,18 +124,8 @@ class _Session(_console.Session):
     @staticmethod
     def connect(switch):
         """Connect to the switch."""
-        alternatives = ['[Pp]assword: ', '>', '#']
-        console = pexpect.spawn(
-            'ssh ' + switch.username + '@' + switch.hostname)
 
-        outcome = console.expect(alternatives)
-        if outcome == 0:
-            console.sendline(switch.password)
-            outcome = console.expect(alternatives)
-        if outcome == 1:
-            console.sendline('en')
-
-        logger.debug('Logged in to switch %r', switch)
+        console = _console.login(switch)
 
         # send a new line so that we can "expect" a prompt again if we already
         # matched when outcome was 2 (pub key auth)

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -18,7 +18,6 @@ Currently the driver uses telnet to connect to the switch's console; in the
 long term we want to be using SNMP.
 """
 
-import pexpect
 import re
 import schema
 import logging


### PR DESCRIPTION
This adds support for the Dell Powerconnect switch and Cisco Nexus.

Configuring the Dell N3000 to use pubkey was a mess. I did configure it and could login using my key, it wasn't smooth though.
```
naved:~/pubkey-ssh/hil$ ssh switch.ipmi.cluster -l naved

R5-PA-C01-U39# (I PRESSED any key here)
Password:Login of naved failed (then I pressed enter)
R5-PA-C01-U39>
R5-PA-C01-U39>en

R5-PA-C01-U39#   
```

Don't know why it tells me about login failed when I did login correctly? Ideally, I would want to reset the switch config and start with a clean slate, but I can't do it since it's a shared switch.