### PR TITLE
Blacklist keystonemiddleware 4.19

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,6 @@ setup(name='hil',
                 'requests_mock>=1.0.0,<2.0',
           ],
           'postgres': ['psycopg2>=2.7,<3.0'],
-          'keystone-auth-backend': ['keystonemiddleware>=4.17,<5.0'],
+          'keystone-auth-backend': ['keystonemiddleware>=4.17,!=4.19,<5.0'],
           'keystone-client': ['python-keystoneclient>=3.13,<4.0'],
       })

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,10 @@ setup(name='hil',
       #
       # For Flask-SQLAlchemy, we are using non-standard semver bounds as
       # release 2.2 is backwards-incompatible.
+      #
+      # We are blacklisting keystonemiddleware version 4.19 due to a bug[3].
+      # [3]: https://bugs.launchpad.net/keystonemiddleware/+bug/1737115
+      # See #923 for details.
       install_requires=['Flask-SQLAlchemy>=2.1,<2.2',
                         'Flask-Migrate>=1.8,<2.0',
                         'Flask-Script>=2.0.5,<3.0',


### PR DESCRIPTION
The 4.19 release of keystonemiddleware contains a commit[0] which
starts making use of the oslo.cache library and specifically some
internal module which interface with memcache. However
python-memcache is an optional backend of the library, and
therefore not installed by default. Additionally, when
keystonemiddleware is not configured for caching, those modules
are not needed. So python-memcache can't be a hard dependency of
keystonemiddleware, but the code treats it as such. This is tracked
at bug [1].

[2] merged which enables lazy loading for oslo.cache, but that
won't be included until the next release, so we need to blacklist
4.19.

0. https://github.com/openstack/keystonemiddleware/commit/9d8e2836fe7fca186e0380d8a532540ff5cc5215
1. https://bugs.launchpad.net/keystonemiddleware/+bug/1737115
2. https://github.com/openstack/keystonemiddleware/commit/35fa0e1da1b96a40aa2aa6dd2be378e4155a22ba