### PR TITLE
Improve JSON-less 404 error readability and prevention with client library

### DIFF
--- a/hil/cli.py
+++ b/hil/cli.py
@@ -18,6 +18,7 @@ from functools import wraps
 
 from hil.client.client import Client, RequestsHTTPClient, KeystoneHTTPClient
 from hil.client.base import FailedAPICallException
+from hil.errors import BadArgumentError
 
 
 logger = logging.getLogger(__name__)
@@ -862,6 +863,8 @@ def main():
         except FailedAPICallException as e:
             sys.exit('Error: %s\n' % e.message)
         except InvalidAPIArgumentsException as e:
+            sys.exit('Error: %s\n' % e.message)
+        except BadArgumentError as e:
             sys.exit('Error: %s\n' % e.message)
         except Exception as e:
             sys.exit('Unexpected error: %s\n' % e.message)

--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -4,7 +4,6 @@ from urlparse import urljoin
 import json
 import re
 from hil.errors import BadArgumentError
-import inspect
 
 
 class FailedAPICallException(Exception):
@@ -69,7 +68,7 @@ class ClientBase(object):
                 error_type=e['type'],
                 message=e['msg'],
             )
-        # Catching 404's that do not return JSON
+        # Catching responses that do not return JSON
         except ValueError:
             return response.content
 
@@ -96,7 +95,6 @@ def check_reserved_chars(*outer_args, **outer_kwargs):
     and dynamically report the error by the offending argument(s)"""
     def wrapper(f):
         """Auxiliary wrapper for check_reserved_chars"""
-        argspec = inspect.getargspec(f)
 
         def reserved_wrap(*args, **kwargs):
             """Wrapper that is passed the arguments of the wrapped function"""

--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -76,12 +76,12 @@ class ClientBase(object):
 
 def _find_reserved(string, slashes_ok=False):
     """Returns a list of illegal characters in a string"""
-    if slashes_ok:
-        p = r"[^A-Za-z0-9 /$_.+!*'(),-]+"
-    else:
-        p = r"[^A-Za-z0-9 $_.+!*'(),-]+"
-    # return all unique chars that exist neither in p nor string
-    return list(set(x for l in re.findall(p, string) for x in l))
+    p = r"[^A-Za-z0-9 /$_.+!*'(),-]"
+    result = re.findall(p, string)
+    if not slashes_ok and '/' in string:
+        result.append('/')
+    # return one of each illegal character in string
+    return list(set(result))
 
 
 def check_reserved(obj_type, obj_string, slashes_ok=False):

--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -73,11 +73,11 @@ class ClientBase(object):
 
     def find_reserved(self, string):
         """Returns a list of illegal characters in a string"""
-        p = '[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+'
+        p = r"[^A-Za-z0-9 $_.+!*'(),-]+"
         return list(x for l in re.findall(p, string) for x in l)
 
     def find_reserved_w_slash(self, string):
         """Returns a list of illegal characters in a string
         excluding `/` for channels and ports"""
-        p = '[^A-Za-z0-9 \/\$\-\_\.\+\!\*\'\(\)\,]+'
+        p = r"[^A-Za-z0-9 /$_.+!*'(),-]+"
         return list(x for l in re.findall(p, string) for x in l)

--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -74,10 +74,10 @@ class ClientBase(object):
     def find_reserved(self, string):
         """Returns a list of illegal characters in a string"""
         p = '[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+'
-        return set(x for l in re.findall(p, string) for x in l)
+        return list(x for l in re.findall(p, string) for x in l)
 
     def find_reserved_w_slash(self, string):
         """Returns a list of illegal characters in a string
-        including `/` for channels and ports"""
+        excluding `/` for channels and ports"""
         p = '[^A-Za-z0-9 \/\$\-\_\.\+\!\*\'\(\)\,]+'
-        return set(x for l in re.findall(p, string) for x in l)
+        return list(x for l in re.findall(p, string) for x in l)

--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -66,5 +66,6 @@ class ClientBase(object):
                 error_type=e['type'],
                 message=e['msg'],
             )
+        # Catching 404's that do not return JSON
         except ValueError:
             return response.content

--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -2,6 +2,7 @@
 
 from urlparse import urljoin
 import json
+import re
 
 
 class FailedAPICallException(Exception):
@@ -69,3 +70,14 @@ class ClientBase(object):
         # Catching 404's that do not return JSON
         except ValueError:
             return response.content
+
+    def find_reserved(self, string):
+        """Returns a list of illegal characters in a string"""
+        p = '[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+'
+        return set(x for l in re.findall(p, string) for x in l)
+
+    def find_reserved_w_slash(self, string):
+        """Returns a list of illegal characters in a string
+        including `/` for channels and ports"""
+        p = '[^A-Za-z0-9 \/\$\-\_\.\+\!\*\'\(\)\,]+'
+        return set(x for l in re.findall(p, string) for x in l)

--- a/hil/client/base.py
+++ b/hil/client/base.py
@@ -60,9 +60,11 @@ class ClientBase(object):
             except ValueError:  # No JSON request body; typical
                                 # For methods PUT, POST, DELETE
                 return
-        else:
+        try:
             e = json.loads(response.content)
             raise FailedAPICallException(
                 error_type=e['type'],
                 message=e['msg'],
             )
+        except ValueError:
+            return response.content

--- a/hil/client/network.py
+++ b/hil/client/network.py
@@ -33,6 +33,18 @@ class Network(ClientBase):
             if bool(bad_chars):
                 raise BadArgumentError("Networks may not contain: %s"
                                        % bad_chars)
+            bad_chars = self.find_reserved(owner)
+            if bool(bad_chars):
+                raise BadArgumentError("Owner may not contain: %s"
+                                       % bad_chars)
+            bad_chars = self.find_reserved(access)
+            if bool(bad_chars):
+                raise BadArgumentError("Access may not contain: %s"
+                                       % bad_chars)
+            bad_chars = self.find_reserved_w_slash(net_id)
+            if bool(bad_chars):
+                raise BadArgumentError("Network ID may not contain: %s"
+                                       % bad_chars)
             url = self.object_url('network', network)
             payload = json.dumps({
                 'owner': owner, 'access': access,

--- a/hil/client/network.py
+++ b/hil/client/network.py
@@ -1,6 +1,7 @@
 """Client support for network related api calls."""
 import json
 from hil.client.base import ClientBase
+from hil.client.base import check_reserved_chars
 
 
 class Network(ClientBase):
@@ -14,21 +15,19 @@ class Network(ClientBase):
             url = self.object_url('networks')
             return self.check_response(self.httpClient.request("GET", url))
 
+        @check_reserved_chars('network')
         def show(self, network):
             """Shows attributes of a network. """
-            self.check_reserved('network', network)
             url = self.object_url('network', network)
             return self.check_response(self.httpClient.request("GET", url))
 
+        @check_reserved_chars('network', 'owner', 'access', 'network id',
+                              slashes_ok=['network id'])
         def create(self, network, owner, access, net_id):
             """Create a link-layer <network>.
 
             See docs/networks.md for details.
             """
-            self.check_reserved('network', network)
-            self.check_reserved('owner', owner)
-            self.check_reserved('access', access)
-            self.check_reserved('Network ID', net_id, slashes_ok=True)
             url = self.object_url('network', network)
             payload = json.dumps({
                 'owner': owner, 'access': access,
@@ -38,25 +37,23 @@ class Network(ClientBase):
                     self.httpClient.request("PUT", url, data=payload)
                     )
 
+        @check_reserved_chars('network')
         def delete(self, network):
             """Delete a <network>. """
-            self.check_reserved('network', network)
             url = self.object_url('network', network)
             return self.check_response(self.httpClient.request("DELETE", url))
 
+        @check_reserved_chars('project', 'network')
         def grant_access(self, project, network):
             """Grants <project> access to <network>. """
-            self.check_reserved('project', project)
-            self.check_reserved('network', network)
             url = self.object_url(
                     'network', network, 'access', project
                     )
             return self.check_response(self.httpClient.request("PUT", url))
 
+        @check_reserved_chars('project', 'network')
         def revoke_access(self, project, network):
             """Removes access of <network> from <project>. """
-            self.check_reserved('project', project)
-            self.check_reserved('network', network)
             url = self.object_url(
                     'network', network, 'access', project
                     )

--- a/hil/client/network.py
+++ b/hil/client/network.py
@@ -1,7 +1,6 @@
 """Client support for network related api calls."""
 import json
 from hil.client.base import ClientBase
-from hil.errors import BadArgumentError
 
 
 class Network(ClientBase):
@@ -17,10 +16,7 @@ class Network(ClientBase):
 
         def show(self, network):
             """Shows attributes of a network. """
-            bad_chars = self.find_reserved(network)
-            if bool(bad_chars):
-                raise BadArgumentError("Networks may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('network', network)
             url = self.object_url('network', network)
             return self.check_response(self.httpClient.request("GET", url))
 
@@ -29,22 +25,10 @@ class Network(ClientBase):
 
             See docs/networks.md for details.
             """
-            bad_chars = self.find_reserved(network)
-            if bool(bad_chars):
-                raise BadArgumentError("Networks may not contain: %s"
-                                       % bad_chars)
-            bad_chars = self.find_reserved(owner)
-            if bool(bad_chars):
-                raise BadArgumentError("Owner may not contain: %s"
-                                       % bad_chars)
-            bad_chars = self.find_reserved(access)
-            if bool(bad_chars):
-                raise BadArgumentError("Access may not contain: %s"
-                                       % bad_chars)
-            bad_chars = self.find_reserved_w_slash(net_id)
-            if bool(bad_chars):
-                raise BadArgumentError("Network ID may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('network', network)
+            self.check_reserved('owner', owner)
+            self.check_reserved('access', access)
+            self.check_reserved('Network ID', net_id, slashes_ok=True)
             url = self.object_url('network', network)
             payload = json.dumps({
                 'owner': owner, 'access': access,
@@ -56,23 +40,14 @@ class Network(ClientBase):
 
         def delete(self, network):
             """Delete a <network>. """
-            bad_chars = self.find_reserved(network)
-            if bool(bad_chars):
-                raise BadArgumentError("Networks may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('network', network)
             url = self.object_url('network', network)
             return self.check_response(self.httpClient.request("DELETE", url))
 
         def grant_access(self, project, network):
             """Grants <project> access to <network>. """
-            bad_chars = self.find_reserved(project)
-            if bool(bad_chars):
-                raise BadArgumentError("Projects may not contain: %s"
-                                       % bad_chars)
-            bad_chars = self.find_reserved(network)
-            if bool(bad_chars):
-                raise BadArgumentError("Networks may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('project', project)
+            self.check_reserved('network', network)
             url = self.object_url(
                     'network', network, 'access', project
                     )
@@ -80,14 +55,8 @@ class Network(ClientBase):
 
         def revoke_access(self, project, network):
             """Removes access of <network> from <project>. """
-            bad_chars = self.find_reserved(project)
-            if bool(bad_chars):
-                raise BadArgumentError("Projects may not contain: %s"
-                                       % bad_chars)
-            bad_chars = self.find_reserved(network)
-            if bool(bad_chars):
-                raise BadArgumentError("Networks may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('project', project)
+            self.check_reserved('network', network)
             url = self.object_url(
                     'network', network, 'access', project
                     )

--- a/hil/client/network.py
+++ b/hil/client/network.py
@@ -1,6 +1,7 @@
 """Client support for network related api calls."""
 import json
 from hil.client.base import ClientBase
+from hil.errors import BadArgumentError
 
 
 class Network(ClientBase):
@@ -16,6 +17,10 @@ class Network(ClientBase):
 
         def show(self, network):
             """Shows attributes of a network. """
+            bad_chars = self.find_reserved(network)
+            if bool(bad_chars):
+                raise BadArgumentError("Networks may not contain: %s"
+                                       % bad_chars)
             url = self.object_url('network', network)
             return self.check_response(self.httpClient.request("GET", url))
 
@@ -24,6 +29,10 @@ class Network(ClientBase):
 
             See docs/networks.md for details.
             """
+            bad_chars = self.find_reserved(network)
+            if bool(bad_chars):
+                raise BadArgumentError("Networks may not contain: %s"
+                                       % bad_chars)
             url = self.object_url('network', network)
             payload = json.dumps({
                 'owner': owner, 'access': access,
@@ -35,11 +44,23 @@ class Network(ClientBase):
 
         def delete(self, network):
             """Delete a <network>. """
+            bad_chars = self.find_reserved(network)
+            if bool(bad_chars):
+                raise BadArgumentError("Networks may not contain: %s"
+                                       % bad_chars)
             url = self.object_url('network', network)
             return self.check_response(self.httpClient.request("DELETE", url))
 
         def grant_access(self, project, network):
             """Grants <project> access to <network>. """
+            bad_chars = self.find_reserved(project)
+            if bool(bad_chars):
+                raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
+            bad_chars = self.find_reserved(network)
+            if bool(bad_chars):
+                raise BadArgumentError("Networks may not contain: %s"
+                                       % bad_chars)
             url = self.object_url(
                     'network', network, 'access', project
                     )
@@ -47,6 +68,14 @@ class Network(ClientBase):
 
         def revoke_access(self, project, network):
             """Removes access of <network> from <project>. """
+            bad_chars = self.find_reserved(project)
+            if bool(bad_chars):
+                raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
+            bad_chars = self.find_reserved(network)
+            if bool(bad_chars):
+                raise BadArgumentError("Networks may not contain: %s"
+                                       % bad_chars)
             url = self.object_url(
                     'network', network, 'access', project
                     )

--- a/hil/client/network.py
+++ b/hil/client/network.py
@@ -15,14 +15,13 @@ class Network(ClientBase):
             url = self.object_url('networks')
             return self.check_response(self.httpClient.request("GET", url))
 
-        @check_reserved_chars('network')
+        @check_reserved_chars()
         def show(self, network):
             """Shows attributes of a network. """
             url = self.object_url('network', network)
             return self.check_response(self.httpClient.request("GET", url))
 
-        @check_reserved_chars('network', 'owner', 'access', 'network id',
-                              slashes_ok=['network id'])
+        @check_reserved_chars(slashes_ok=['net_id'])
         def create(self, network, owner, access, net_id):
             """Create a link-layer <network>.
 
@@ -37,13 +36,13 @@ class Network(ClientBase):
                     self.httpClient.request("PUT", url, data=payload)
                     )
 
-        @check_reserved_chars('network')
+        @check_reserved_chars()
         def delete(self, network):
             """Delete a <network>. """
             url = self.object_url('network', network)
             return self.check_response(self.httpClient.request("DELETE", url))
 
-        @check_reserved_chars('project', 'network')
+        @check_reserved_chars()
         def grant_access(self, project, network):
             """Grants <project> access to <network>. """
             url = self.object_url(
@@ -51,7 +50,7 @@ class Network(ClientBase):
                     )
             return self.check_response(self.httpClient.request("PUT", url))
 
-        @check_reserved_chars('project', 'network')
+        @check_reserved_chars()
         def revoke_access(self, project, network):
             """Removes access of <network> from <project>. """
             url = self.object_url(

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -108,6 +108,14 @@ class Node(ClientBase):
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
                                    % bad_chars)
+        bad_chars = self.find_reserved(network)
+        if bool(bad_chars):
+            raise BadArgumentError("Networks may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved_w_slash(channel)
+        if bool(bad_chars):
+            raise BadArgumentError("Channels may not contain: %s"
+                                   % bad_chars)
         url = self.object_url(
                 'node', node, 'nic', nic, 'connect_network'
                 )
@@ -127,6 +135,10 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(nic)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved(network)
+        if bool(bad_chars):
+            raise BadArgumentError("Networks may not contain: %s"
                                    % bad_chars)
         url = self.object_url(
                 'node', node, 'nic', nic, 'detach_network'

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -1,6 +1,7 @@
 """Client support for node related api calls."""
 import json
 from hil.client.base import ClientBase
+from hil.client.base import check_reserved_chars
 
 
 class Node(ClientBase):
@@ -14,9 +15,9 @@ class Node(ClientBase):
         url = self.object_url('nodes', is_free)
         return self.check_response(self.httpClient.request('GET', url))
 
+    @check_reserved_chars('node')
     def show(self, node_name):
         """Shows attributes of a given node """
-        self.check_reserved('node', node_name)
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('GET', url))
 
@@ -35,50 +36,46 @@ class Node(ClientBase):
         # obm_types = ["ipmi", "mock"]
         raise NotImplementedError
 
+    @check_reserved_chars('node')
     def delete(self, node_name):
         """Deletes the node from database. """
-        self.check_reserved('node', node_name)
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
+    @check_reserved_chars('node')
     def power_cycle(self, node_name, force=False):
         """Power cycles the <node> """
-        self.check_reserved('node', node_name)
         url = self.object_url('node', node_name, 'power_cycle')
         payload = json.dumps({'force': force})
         return self.check_response(
                 self.httpClient.request('POST', url, data=payload)
                 )
 
+    @check_reserved_chars('node')
     def power_off(self, node_name):
         """Power offs the <node> """
-        self.check_reserved('node', node_name)
         url = self.object_url('node', node_name, 'power_off')
         return self.check_response(self.httpClient.request('POST', url))
 
+    @check_reserved_chars('node', 'nic')
     def add_nic(self, node_name, nic_name, macaddr):
         """Add a <nic> to <node>"""
-        self.check_reserved('node', node_name)
-        self.check_reserved('nic', nic_name)
         url = self.object_url('node', node_name, 'nic', nic_name)
         payload = json.dumps({'macaddr': macaddr})
         return self.check_response(
                 self.httpClient.request('PUT', url, data=payload)
                 )
 
+    @check_reserved_chars('node', 'nic')
     def remove_nic(self, node_name, nic_name):
         """Remove a <nic> from <node>"""
-        self.check_reserved('node', node_name)
-        self.check_reserved('nic', nic_name)
         url = self.object_url('node', node_name, 'nic', nic_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
+    @check_reserved_chars('node', 'nic', 'network', 'channel',
+                          slashes_ok=['channel'])
     def connect_network(self, node, nic, network, channel):
         """Connect <node> to <network> on given <nic> and <channel>"""
-        self.check_reserved('node', node)
-        self.check_reserved('nic', nic)
-        self.check_reserved('network', network)
-        self.check_reserved('channel', channel, slashes_ok=True)
         url = self.object_url(
                 'node', node, 'nic', nic, 'connect_network'
                 )
@@ -89,11 +86,9 @@ class Node(ClientBase):
                 self.httpClient.request('POST', url, data=payload)
                 )
 
+    @check_reserved_chars('node', 'nic', 'network')
     def detach_network(self, node, nic, network):
         """Disconnect <node> from <network> on the given <nic>. """
-        self.check_reserved('node', node)
-        self.check_reserved('nic', nic)
-        self.check_reserved('network', network)
         url = self.object_url(
                 'node', node, 'nic', nic, 'detach_network'
                 )
@@ -106,14 +101,14 @@ class Node(ClientBase):
         """Display console log for <node> """
         raise NotImplementedError
 
+    @check_reserved_chars('node')
     def start_console(self, node):
         """Start logging console output from <node> """
-        self.check_reserved('node', node)
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('PUT', url))
 
+    @check_reserved_chars('node')
     def stop_console(self, node):
         """Stop logging console output from <node> and delete the log"""
-        self.check_reserved('node', node)
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('DELETE', url))

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -18,7 +18,7 @@ class Node(ClientBase):
 
     def show(self, node_name):
         """Shows attributes of a given node """
-        bad_chars = _find_reserved(self, node_name)
+        bad_chars = _find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
@@ -42,11 +42,19 @@ class Node(ClientBase):
 
     def delete(self, node_name):
         """Deletes the node from database. """
+        bad_chars = _find_reserved(node_name)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
     def power_cycle(self, node_name, force=False):
         """Power cycles the <node> """
+        bad_chars = _find_reserved(node_name)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
         url = self.object_url('node', node_name, 'power_cycle')
         payload = json.dumps({'force': force})
         return self.check_response(
@@ -54,11 +62,23 @@ class Node(ClientBase):
                 )
 
     def power_off(self, node_name):
+        bad_chars = _find_reserved(node_name)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
         """Power offs the <node> """
         url = self.object_url('node', node_name, 'power_off')
         return self.check_response(self.httpClient.request('POST', url))
 
     def add_nic(self, node_name, nic_name, macaddr):
+        bad_chars = _find_reserved(node_name)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
+        bad_chars = _find_reserved(nic_name)
+        if bool(bad_chars):
+            raise BadArgumentError("Nics may not contain: %s"
+                                % bad_chars)
         """Add a <nic> to <node>"""
         url = self.object_url('node', node_name, 'nic', nic_name)
         payload = json.dumps({'macaddr': macaddr})
@@ -108,9 +128,13 @@ class Node(ClientBase):
         return self.check_response(self.httpClient.request('DELETE', url))
 
 
-def _find_reserved(obj, string):
+def _find_reserved(string):
+    """Returns a list of illegal characters in a string"""
+    p = '[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+'
+    return set(x for l in re.findall(p, string) for x in l)
+
+def _find_reserved_w_slash(string):
     """Returns a list of illegal characters in a string
-    based on the related object type"""
-    if type(obj) is Node:
-        p = '[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+'
-        return set(x for l in re.findall(p, string) for x in l)
+    including `/` for channels and ports"""
+    p = '[^A-Za-z0-9 \/\$\-\_\.\+\!\*\'\(\)\,]+'
+    return set(x for l in re.findall(p, string) for x in l)

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -1,7 +1,6 @@
 """Client support for node related api calls."""
 import json
 from hil.client.base import ClientBase
-from hil.errors import BadArgumentError
 
 
 class Node(ClientBase):
@@ -17,10 +16,7 @@ class Node(ClientBase):
 
     def show(self, node_name):
         """Shows attributes of a given node """
-        bad_chars = self.find_reserved(node_name)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node_name)
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('GET', url))
 
@@ -41,19 +37,13 @@ class Node(ClientBase):
 
     def delete(self, node_name):
         """Deletes the node from database. """
-        bad_chars = self.find_reserved(node_name)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node_name)
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
     def power_cycle(self, node_name, force=False):
         """Power cycles the <node> """
-        bad_chars = self.find_reserved(node_name)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node_name)
         url = self.object_url('node', node_name, 'power_cycle')
         payload = json.dumps({'force': force})
         return self.check_response(
@@ -62,23 +52,14 @@ class Node(ClientBase):
 
     def power_off(self, node_name):
         """Power offs the <node> """
-        bad_chars = self.find_reserved(node_name)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node_name)
         url = self.object_url('node', node_name, 'power_off')
         return self.check_response(self.httpClient.request('POST', url))
 
     def add_nic(self, node_name, nic_name, macaddr):
         """Add a <nic> to <node>"""
-        bad_chars = self.find_reserved(node_name)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(nic_name)
-        if bool(bad_chars):
-            raise BadArgumentError("Nics may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node_name)
+        self.check_reserved('nic', nic_name)
         url = self.object_url('node', node_name, 'nic', nic_name)
         payload = json.dumps({'macaddr': macaddr})
         return self.check_response(
@@ -87,35 +68,17 @@ class Node(ClientBase):
 
     def remove_nic(self, node_name, nic_name):
         """Remove a <nic> from <node>"""
-        bad_chars = self.find_reserved(node_name)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(nic_name)
-        if bool(bad_chars):
-            raise BadArgumentError("Nics may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node_name)
+        self.check_reserved('nic', nic_name)
         url = self.object_url('node', node_name, 'nic', nic_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
     def connect_network(self, node, nic, network, channel):
         """Connect <node> to <network> on given <nic> and <channel>"""
-        bad_chars = self.find_reserved(node)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(nic)
-        if bool(bad_chars):
-            raise BadArgumentError("Nics may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(network)
-        if bool(bad_chars):
-            raise BadArgumentError("Networks may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved_w_slash(channel)
-        if bool(bad_chars):
-            raise BadArgumentError("Channels may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node)
+        self.check_reserved('nic', nic)
+        self.check_reserved('network', network)
+        self.check_reserved('channel', channel, slashes_ok=True)
         url = self.object_url(
                 'node', node, 'nic', nic, 'connect_network'
                 )
@@ -128,18 +91,9 @@ class Node(ClientBase):
 
     def detach_network(self, node, nic, network):
         """Disconnect <node> from <network> on the given <nic>. """
-        bad_chars = self.find_reserved(node)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(nic)
-        if bool(bad_chars):
-            raise BadArgumentError("Nics may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(network)
-        if bool(bad_chars):
-            raise BadArgumentError("Networks may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node)
+        self.check_reserved('nic', nic)
+        self.check_reserved('network', network)
         url = self.object_url(
                 'node', node, 'nic', nic, 'detach_network'
                 )
@@ -154,18 +108,12 @@ class Node(ClientBase):
 
     def start_console(self, node):
         """Start logging console output from <node> """
-        bad_chars = self.find_reserved(node)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node)
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('PUT', url))
 
     def stop_console(self, node):
         """Stop logging console output from <node> and delete the log"""
-        bad_chars = self.find_reserved(node)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('node', node)
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('DELETE', url))

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -62,15 +62,16 @@ class Node(ClientBase):
                 )
 
     def power_off(self, node_name):
+        """Power offs the <node> """
         bad_chars = _find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
-        """Power offs the <node> """
         url = self.object_url('node', node_name, 'power_off')
         return self.check_response(self.httpClient.request('POST', url))
 
     def add_nic(self, node_name, nic_name, macaddr):
+        """Add a <nic> to <node>"""
         bad_chars = _find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
@@ -79,7 +80,6 @@ class Node(ClientBase):
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
                                 % bad_chars)
-        """Add a <nic> to <node>"""
         url = self.object_url('node', node_name, 'nic', nic_name)
         payload = json.dumps({'macaddr': macaddr})
         return self.check_response(
@@ -88,11 +88,27 @@ class Node(ClientBase):
 
     def remove_nic(self, node_name, nic_name):
         """Remove a <nic> from <node>"""
+        bad_chars = _find_reserved(node_name)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
+        bad_chars = _find_reserved(nic_name)
+        if bool(bad_chars):
+            raise BadArgumentError("Nics may not contain: %s"
+                                % bad_chars)
         url = self.object_url('node', node_name, 'nic', nic_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
     def connect_network(self, node, nic, network, channel):
         """Connect <node> to <network> on given <nic> and <channel>"""
+        bad_chars = _find_reserved(node)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
+        bad_chars = _find_reserved(nic)
+        if bool(bad_chars):
+            raise BadArgumentError("Nics may not contain: %s"
+                                % bad_chars)
         url = self.object_url(
                 'node', node, 'nic', nic, 'connect_network'
                 )
@@ -105,6 +121,14 @@ class Node(ClientBase):
 
     def detach_network(self, node, nic, network):
         """Disconnect <node> from <network> on the given <nic>. """
+        bad_chars = _find_reserved(node)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
+        bad_chars = _find_reserved(nic)
+        if bool(bad_chars):
+            raise BadArgumentError("Nics may not contain: %s"
+                                % bad_chars)
         url = self.object_url(
                 'node', node, 'nic', nic, 'detach_network'
                 )
@@ -119,11 +143,19 @@ class Node(ClientBase):
 
     def start_console(self, node):
         """Start logging console output from <node> """
+        bad_chars = _find_reserved(node)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('PUT', url))
 
     def stop_console(self, node):
         """Stop logging console output from <node> and delete the log"""
+        bad_chars = _find_reserved(node)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                % bad_chars)
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('DELETE', url))
 

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -18,7 +18,7 @@ class Node(ClientBase):
 
     def show(self, node_name):
         """Shows attributes of a given node """
-        bad_chars = _find_reserved(node_name)
+        bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
@@ -42,7 +42,7 @@ class Node(ClientBase):
 
     def delete(self, node_name):
         """Deletes the node from database. """
-        bad_chars = _find_reserved(node_name)
+        bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
@@ -51,7 +51,7 @@ class Node(ClientBase):
 
     def power_cycle(self, node_name, force=False):
         """Power cycles the <node> """
-        bad_chars = _find_reserved(node_name)
+        bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
@@ -63,7 +63,7 @@ class Node(ClientBase):
 
     def power_off(self, node_name):
         """Power offs the <node> """
-        bad_chars = _find_reserved(node_name)
+        bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
@@ -72,11 +72,11 @@ class Node(ClientBase):
 
     def add_nic(self, node_name, nic_name, macaddr):
         """Add a <nic> to <node>"""
-        bad_chars = _find_reserved(node_name)
+        bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
-        bad_chars = _find_reserved(nic_name)
+        bad_chars = self.find_reserved(nic_name)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
                                 % bad_chars)
@@ -88,11 +88,11 @@ class Node(ClientBase):
 
     def remove_nic(self, node_name, nic_name):
         """Remove a <nic> from <node>"""
-        bad_chars = _find_reserved(node_name)
+        bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
-        bad_chars = _find_reserved(nic_name)
+        bad_chars = self.find_reserved(nic_name)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
                                 % bad_chars)
@@ -101,11 +101,11 @@ class Node(ClientBase):
 
     def connect_network(self, node, nic, network, channel):
         """Connect <node> to <network> on given <nic> and <channel>"""
-        bad_chars = _find_reserved(node)
+        bad_chars = self.find_reserved(node)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
-        bad_chars = _find_reserved(nic)
+        bad_chars = self.find_reserved(nic)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
                                 % bad_chars)
@@ -121,11 +121,11 @@ class Node(ClientBase):
 
     def detach_network(self, node, nic, network):
         """Disconnect <node> from <network> on the given <nic>. """
-        bad_chars = _find_reserved(node)
+        bad_chars = self.find_reserved(node)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
-        bad_chars = _find_reserved(nic)
+        bad_chars = self.find_reserved(nic)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
                                 % bad_chars)
@@ -143,7 +143,7 @@ class Node(ClientBase):
 
     def start_console(self, node):
         """Start logging console output from <node> """
-        bad_chars = _find_reserved(node)
+        bad_chars = self.find_reserved(node)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
@@ -152,7 +152,7 @@ class Node(ClientBase):
 
     def stop_console(self, node):
         """Stop logging console output from <node> and delete the log"""
-        bad_chars = _find_reserved(node)
+        bad_chars = self.find_reserved(node)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
                                 % bad_chars)
@@ -160,13 +160,13 @@ class Node(ClientBase):
         return self.check_response(self.httpClient.request('DELETE', url))
 
 
-def _find_reserved(string):
-    """Returns a list of illegal characters in a string"""
-    p = '[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+'
-    return set(x for l in re.findall(p, string) for x in l)
+#def _find_reserved(string):
+#    """Returns a list of illegal characters in a string"""
+#    p = '[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+'
+#    return set(x for l in re.findall(p, string) for x in l)
 
-def _find_reserved_w_slash(string):
-    """Returns a list of illegal characters in a string
-    including `/` for channels and ports"""
-    p = '[^A-Za-z0-9 \/\$\-\_\.\+\!\*\'\(\)\,]+'
-    return set(x for l in re.findall(p, string) for x in l)
+#def _find_reserved_w_slash(string):
+#    """Returns a list of illegal characters in a string
+#    including `/` for channels and ports"""
+#    p = '[^A-Za-z0-9 \/\$\-\_\.\+\!\*\'\(\)\,]+'
+#    return set(x for l in re.findall(p, string) for x in l)

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -15,7 +15,7 @@ class Node(ClientBase):
         url = self.object_url('nodes', is_free)
         return self.check_response(self.httpClient.request('GET', url))
 
-    @check_reserved_chars('node')
+    @check_reserved_chars()
     def show(self, node_name):
         """Shows attributes of a given node """
         url = self.object_url('node', node_name)
@@ -36,13 +36,13 @@ class Node(ClientBase):
         # obm_types = ["ipmi", "mock"]
         raise NotImplementedError
 
-    @check_reserved_chars('node')
+    @check_reserved_chars()
     def delete(self, node_name):
         """Deletes the node from database. """
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
-    @check_reserved_chars('node')
+    @check_reserved_chars(dont_check=['force'])
     def power_cycle(self, node_name, force=False):
         """Power cycles the <node> """
         url = self.object_url('node', node_name, 'power_cycle')
@@ -51,13 +51,13 @@ class Node(ClientBase):
                 self.httpClient.request('POST', url, data=payload)
                 )
 
-    @check_reserved_chars('node')
+    @check_reserved_chars()
     def power_off(self, node_name):
         """Power offs the <node> """
         url = self.object_url('node', node_name, 'power_off')
         return self.check_response(self.httpClient.request('POST', url))
 
-    @check_reserved_chars('node', 'nic')
+    @check_reserved_chars(dont_check=['macaddr'])
     def add_nic(self, node_name, nic_name, macaddr):
         """Add a <nic> to <node>"""
         url = self.object_url('node', node_name, 'nic', nic_name)
@@ -66,14 +66,13 @@ class Node(ClientBase):
                 self.httpClient.request('PUT', url, data=payload)
                 )
 
-    @check_reserved_chars('node', 'nic')
+    @check_reserved_chars()
     def remove_nic(self, node_name, nic_name):
         """Remove a <nic> from <node>"""
         url = self.object_url('node', node_name, 'nic', nic_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
-    @check_reserved_chars('node', 'nic', 'network', 'channel',
-                          slashes_ok=['channel'])
+    @check_reserved_chars(slashes_ok=['channel'])
     def connect_network(self, node, nic, network, channel):
         """Connect <node> to <network> on given <nic> and <channel>"""
         url = self.object_url(
@@ -86,7 +85,7 @@ class Node(ClientBase):
                 self.httpClient.request('POST', url, data=payload)
                 )
 
-    @check_reserved_chars('node', 'nic', 'network')
+    @check_reserved_chars()
     def detach_network(self, node, nic, network):
         """Disconnect <node> from <network> on the given <nic>. """
         url = self.object_url(
@@ -101,13 +100,13 @@ class Node(ClientBase):
         """Display console log for <node> """
         raise NotImplementedError
 
-    @check_reserved_chars('node')
+    @check_reserved_chars()
     def start_console(self, node):
         """Start logging console output from <node> """
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('PUT', url))
 
-    @check_reserved_chars('node')
+    @check_reserved_chars()
     def stop_console(self, node):
         """Stop logging console output from <node> and delete the log"""
         url = self.object_url('node', node, 'console')

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -1,6 +1,9 @@
 """Client support for node related api calls."""
 import json
 from hil.client.base import ClientBase
+import re
+from hil.errors import NotFoundError
+
 
 
 class Node(ClientBase):
@@ -14,8 +17,11 @@ class Node(ClientBase):
         url = self.object_url('nodes', is_free)
         return self.check_response(self.httpClient.request('GET', url))
 
+
     def show(self, node_name):
         """Shows attributes of a given node """
+        #if _has_reserved(node_name):
+        #   raise NotFoundError("Node %s does not exist." % node_name)
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('GET', url))
 
@@ -100,3 +106,8 @@ class Node(ClientBase):
         """Stop logging console output from <node> and delete the log"""
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('DELETE', url))
+
+
+def _has_reserved(string, search=re.compile('[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+').search):
+    """Returns true if <string> contains URL-reserved characters"""
+    return bool(search(string))

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -1,7 +1,6 @@
 """Client support for node related api calls."""
 import json
 from hil.client.base import ClientBase
-import re
 from hil.errors import BadArgumentError
 
 
@@ -21,7 +20,7 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('GET', url))
 
@@ -45,7 +44,7 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url('node', node_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
@@ -54,7 +53,7 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url('node', node_name, 'power_cycle')
         payload = json.dumps({'force': force})
         return self.check_response(
@@ -66,7 +65,7 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url('node', node_name, 'power_off')
         return self.check_response(self.httpClient.request('POST', url))
 
@@ -75,11 +74,11 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         bad_chars = self.find_reserved(nic_name)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url('node', node_name, 'nic', nic_name)
         payload = json.dumps({'macaddr': macaddr})
         return self.check_response(
@@ -91,11 +90,11 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node_name)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         bad_chars = self.find_reserved(nic_name)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url('node', node_name, 'nic', nic_name)
         return self.check_response(self.httpClient.request('DELETE', url))
 
@@ -104,11 +103,11 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         bad_chars = self.find_reserved(nic)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url(
                 'node', node, 'nic', nic, 'connect_network'
                 )
@@ -124,11 +123,11 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         bad_chars = self.find_reserved(nic)
         if bool(bad_chars):
             raise BadArgumentError("Nics may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url(
                 'node', node, 'nic', nic, 'detach_network'
                 )
@@ -146,7 +145,7 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('PUT', url))
 
@@ -155,18 +154,6 @@ class Node(ClientBase):
         bad_chars = self.find_reserved(node)
         if bool(bad_chars):
             raise BadArgumentError("Nodes may not contain: %s"
-                                % bad_chars)
+                                   % bad_chars)
         url = self.object_url('node', node, 'console')
         return self.check_response(self.httpClient.request('DELETE', url))
-
-
-#def _find_reserved(string):
-#    """Returns a list of illegal characters in a string"""
-#    p = '[^A-Za-z0-9 \$\-\_\.\+\!\*\'\(\)\,]+'
-#    return set(x for l in re.findall(p, string) for x in l)
-
-#def _find_reserved_w_slash(string):
-#    """Returns a list of illegal characters in a string
-#    including `/` for channels and ports"""
-#    p = '[^A-Za-z0-9 \/\$\-\_\.\+\!\*\'\(\)\,]+'
-#    return set(x for l in re.findall(p, string) for x in l)

--- a/hil/client/project.py
+++ b/hil/client/project.py
@@ -1,6 +1,7 @@
 """Client support for project related api calls."""
 import json
 from hil.client.base import ClientBase
+from hil.errors import BadArgumentError
 
 
 class Project(ClientBase):
@@ -17,11 +18,19 @@ class Project(ClientBase):
 
         def nodes_in(self, project_name):
             """Lists nodes allocated to project <project_name> """
+            bad_chars = self.find_reserved(project_name)
+            if bool(bad_chars):
+                raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
             url = self.object_url('project', project_name, 'nodes')
             return self.check_response(self.httpClient.request("GET", url))
 
         def networks_in(self, project_name):
             """Lists nodes allocated to project <project_name> """
+            bad_chars = self.find_reserved(project_name)
+            if bool(bad_chars):
+                raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
             url = self.object_url(
                     'project', project_name, 'networks'
                     )
@@ -29,16 +38,28 @@ class Project(ClientBase):
 
         def create(self, project_name):
             """Creates a project named <project_name> """
+            bad_chars = self.find_reserved(project_name)
+            if bool(bad_chars):
+                raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
             url = self.object_url('project', project_name)
             return self.check_response(self.httpClient.request("PUT", url))
 
         def delete(self, project_name):
             """Deletes a project named <project_name> """
+            bad_chars = self.find_reserved(project_name)
+            if bool(bad_chars):
+                raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
             url = self.object_url('project', project_name)
             return self.check_response(self.httpClient.request("DELETE", url))
 
         def connect(self, project_name, node_name):
             """Adds a node to a project. """
+            bad_chars = self.find_reserved(project_name)
+            if bool(bad_chars):
+                raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
             url = self.object_url(
                     'project', project_name, 'connect_node'
                     )
@@ -49,6 +70,10 @@ class Project(ClientBase):
 
         def detach(self, project_name, node_name):
             """Detaches a node from a project. """
+            bad_chars = self.find_reserved(project_name)
+            if bool(bad_chars):
+                raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
             url = self.object_url('project', project_name, 'detach_node')
             self.payload = json.dumps({'node': node_name})
             return self.check_response(

--- a/hil/client/project.py
+++ b/hil/client/project.py
@@ -1,6 +1,7 @@
 """Client support for project related api calls."""
 import json
 from hil.client.base import ClientBase
+from hil.client.base import check_reserved_chars
 
 
 class Project(ClientBase):
@@ -15,36 +16,35 @@ class Project(ClientBase):
             url = self.object_url('/projects')
             return self.check_response(self.httpClient.request("GET", url))
 
+        @check_reserved_chars('project')
         def nodes_in(self, project_name):
             """Lists nodes allocated to project <project_name> """
-            self.check_reserved('project', project_name)
             url = self.object_url('project', project_name, 'nodes')
             return self.check_response(self.httpClient.request("GET", url))
 
+        @check_reserved_chars('project')
         def networks_in(self, project_name):
             """Lists nodes allocated to project <project_name> """
-            self.check_reserved('project', project_name)
             url = self.object_url(
                     'project', project_name, 'networks'
                     )
             return self.check_response(self.httpClient.request("GET", url))
 
+        @check_reserved_chars('project')
         def create(self, project_name):
             """Creates a project named <project_name> """
-            self.check_reserved('project', project_name)
             url = self.object_url('project', project_name)
             return self.check_response(self.httpClient.request("PUT", url))
 
+        @check_reserved_chars('project')
         def delete(self, project_name):
             """Deletes a project named <project_name> """
-            self.check_reserved('project', project_name)
             url = self.object_url('project', project_name)
             return self.check_response(self.httpClient.request("DELETE", url))
 
+        @check_reserved_chars('project', 'node')
         def connect(self, project_name, node_name):
             """Adds a node to a project. """
-            self.check_reserved('project', project_name)
-            self.check_reserved('node', node_name)
             url = self.object_url(
                     'project', project_name, 'connect_node'
                     )
@@ -53,10 +53,9 @@ class Project(ClientBase):
                     self.httpClient.request("POST", url, data=self.payload)
                     )
 
+        @check_reserved_chars('project', 'node')
         def detach(self, project_name, node_name):
             """Detaches a node from a project. """
-            self.check_reserved('project', project_name)
-            self.check_reserved('node', node_name)
             url = self.object_url('project', project_name, 'detach_node')
             self.payload = json.dumps({'node': node_name})
             return self.check_response(

--- a/hil/client/project.py
+++ b/hil/client/project.py
@@ -16,13 +16,13 @@ class Project(ClientBase):
             url = self.object_url('/projects')
             return self.check_response(self.httpClient.request("GET", url))
 
-        @check_reserved_chars('project')
+        @check_reserved_chars()
         def nodes_in(self, project_name):
             """Lists nodes allocated to project <project_name> """
             url = self.object_url('project', project_name, 'nodes')
             return self.check_response(self.httpClient.request("GET", url))
 
-        @check_reserved_chars('project')
+        @check_reserved_chars()
         def networks_in(self, project_name):
             """Lists nodes allocated to project <project_name> """
             url = self.object_url(
@@ -30,19 +30,19 @@ class Project(ClientBase):
                     )
             return self.check_response(self.httpClient.request("GET", url))
 
-        @check_reserved_chars('project')
+        @check_reserved_chars()
         def create(self, project_name):
             """Creates a project named <project_name> """
             url = self.object_url('project', project_name)
             return self.check_response(self.httpClient.request("PUT", url))
 
-        @check_reserved_chars('project')
+        @check_reserved_chars()
         def delete(self, project_name):
             """Deletes a project named <project_name> """
             url = self.object_url('project', project_name)
             return self.check_response(self.httpClient.request("DELETE", url))
 
-        @check_reserved_chars('project', 'node')
+        @check_reserved_chars()
         def connect(self, project_name, node_name):
             """Adds a node to a project. """
             url = self.object_url(
@@ -53,7 +53,7 @@ class Project(ClientBase):
                     self.httpClient.request("POST", url, data=self.payload)
                     )
 
-        @check_reserved_chars('project', 'node')
+        @check_reserved_chars()
         def detach(self, project_name, node_name):
             """Detaches a node from a project. """
             url = self.object_url('project', project_name, 'detach_node')

--- a/hil/client/project.py
+++ b/hil/client/project.py
@@ -1,7 +1,6 @@
 """Client support for project related api calls."""
 import json
 from hil.client.base import ClientBase
-from hil.errors import BadArgumentError
 
 
 class Project(ClientBase):
@@ -18,19 +17,13 @@ class Project(ClientBase):
 
         def nodes_in(self, project_name):
             """Lists nodes allocated to project <project_name> """
-            bad_chars = self.find_reserved(project_name)
-            if bool(bad_chars):
-                raise BadArgumentError("Projects may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('project', project_name)
             url = self.object_url('project', project_name, 'nodes')
             return self.check_response(self.httpClient.request("GET", url))
 
         def networks_in(self, project_name):
             """Lists nodes allocated to project <project_name> """
-            bad_chars = self.find_reserved(project_name)
-            if bool(bad_chars):
-                raise BadArgumentError("Projects may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('project', project_name)
             url = self.object_url(
                     'project', project_name, 'networks'
                     )
@@ -38,32 +31,20 @@ class Project(ClientBase):
 
         def create(self, project_name):
             """Creates a project named <project_name> """
-            bad_chars = self.find_reserved(project_name)
-            if bool(bad_chars):
-                raise BadArgumentError("Projects may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('project', project_name)
             url = self.object_url('project', project_name)
             return self.check_response(self.httpClient.request("PUT", url))
 
         def delete(self, project_name):
             """Deletes a project named <project_name> """
-            bad_chars = self.find_reserved(project_name)
-            if bool(bad_chars):
-                raise BadArgumentError("Projects may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('project', project_name)
             url = self.object_url('project', project_name)
             return self.check_response(self.httpClient.request("DELETE", url))
 
         def connect(self, project_name, node_name):
             """Adds a node to a project. """
-            bad_chars = self.find_reserved(project_name)
-            if bool(bad_chars):
-                raise BadArgumentError("Projects may not contain: %s"
-                                       % bad_chars)
-            bad_chars = self.find_reserved(node_name)
-            if bool(bad_chars):
-                raise BadArgumentError("Nodes may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('project', project_name)
+            self.check_reserved('node', node_name)
             url = self.object_url(
                     'project', project_name, 'connect_node'
                     )
@@ -74,14 +55,8 @@ class Project(ClientBase):
 
         def detach(self, project_name, node_name):
             """Detaches a node from a project. """
-            bad_chars = self.find_reserved(project_name)
-            if bool(bad_chars):
-                raise BadArgumentError("Projects may not contain: %s"
-                                       % bad_chars)
-            bad_chars = self.find_reserved(node_name)
-            if bool(bad_chars):
-                raise BadArgumentError("Nodes may not contain: %s"
-                                       % bad_chars)
+            self.check_reserved('project', project_name)
+            self.check_reserved('node', node_name)
             url = self.object_url('project', project_name, 'detach_node')
             self.payload = json.dumps({'node': node_name})
             return self.check_response(

--- a/hil/client/project.py
+++ b/hil/client/project.py
@@ -60,6 +60,10 @@ class Project(ClientBase):
             if bool(bad_chars):
                 raise BadArgumentError("Projects may not contain: %s"
                                        % bad_chars)
+            bad_chars = self.find_reserved(node_name)
+            if bool(bad_chars):
+                raise BadArgumentError("Nodes may not contain: %s"
+                                       % bad_chars)
             url = self.object_url(
                     'project', project_name, 'connect_node'
                     )
@@ -73,6 +77,10 @@ class Project(ClientBase):
             bad_chars = self.find_reserved(project_name)
             if bool(bad_chars):
                 raise BadArgumentError("Projects may not contain: %s"
+                                       % bad_chars)
+            bad_chars = self.find_reserved(node_name)
+            if bool(bad_chars):
+                raise BadArgumentError("Nodes may not contain: %s"
                                        % bad_chars)
             url = self.object_url('project', project_name, 'detach_node')
             self.payload = json.dumps({'node': node_name})

--- a/hil/client/switch.py
+++ b/hil/client/switch.py
@@ -1,6 +1,7 @@
 """Client support for switch related api calls."""
 import json
 from hil.client.base import ClientBase
+from hil.errors import BadArgumentError
 
 
 class Switch(ClientBase):
@@ -26,11 +27,19 @@ class Switch(ClientBase):
 
     def delete(self, switch):
         """Deletes the switch named <switch>."""
+        bad_chars = self.find_reserved(switch)
+        if bool(bad_chars):
+            raise BadArgumentError("Switches may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch)
         return self.check_response(self.httpClient.request("DELETE", url))
 
     def show(self, switch):
         """Shows attributes of <switch>. """
+        bad_chars = self.find_reserved(switch)
+        if bool(bad_chars):
+            raise BadArgumentError("Switches may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch)
         return self.check_response(self.httpClient.request("GET", url))
 
@@ -40,16 +49,40 @@ class Port(ClientBase):
 
     def register(self, switch, port):
         """Register a <port> with <switch>. """
+        bad_chars = self.find_reserved(switch)
+        if bool(bad_chars):
+            raise BadArgumentError("Switches may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved_w_slash(port)
+        if bool(bad_chars):
+            raise BadArgumentError("Ports may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("PUT", url))
 
     def delete(self, switch, port):
         """Deletes information of the <port> for <switch> """
+        bad_chars = self.find_reserved(switch)
+        if bool(bad_chars):
+            raise BadArgumentError("Switches may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved_w_slash(port)
+        if bool(bad_chars):
+            raise BadArgumentError("Ports may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("DELETE", url))
 
     def connect_nic(self, switch, port, node, nic):
         """Connects <port> of <switch> to <nic> of <node>. """
+        bad_chars = self.find_reserved(switch)
+        if bool(bad_chars):
+            raise BadArgumentError("Switches may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved_w_slash(port)
+        if bool(bad_chars):
+            raise BadArgumentError("Ports may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch, 'port', port, 'connect_nic')
         payload = json.dumps({'node': node, 'nic': nic})
         return self.check_response(
@@ -58,15 +91,39 @@ class Port(ClientBase):
 
     def detach_nic(self, switch, port):
         """"Detaches <port> of <switch>. """
+        bad_chars = self.find_reserved(switch)
+        if bool(bad_chars):
+            raise BadArgumentError("Switches may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved_w_slash(port)
+        if bool(bad_chars):
+            raise BadArgumentError("Ports may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch, 'port', port, 'detach_nic')
         return self.check_response(self.httpClient.request("POST", url))
 
     def show(self, switch, port):
         """Show what's connected to <port>"""
+        bad_chars = self.find_reserved(switch)
+        if bool(bad_chars):
+            raise BadArgumentError("Switches may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved_w_slash(port)
+        if bool(bad_chars):
+            raise BadArgumentError("Ports may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("GET", url))
 
     def port_revert(self, switch, port):
         """removes all vlans from a switch port"""
+        bad_chars = self.find_reserved(switch)
+        if bool(bad_chars):
+            raise BadArgumentError("Switches may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved_w_slash(port)
+        if bool(bad_chars):
+            raise BadArgumentError("Ports may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch, 'port', port, 'revert')
         return self.check_response(self.httpClient.request("POST", url))

--- a/hil/client/switch.py
+++ b/hil/client/switch.py
@@ -1,6 +1,7 @@
 """Client support for switch related api calls."""
 import json
 from hil.client.base import ClientBase
+from hil.client.base import check_reserved_chars
 
 
 class Switch(ClientBase):
@@ -24,15 +25,15 @@ class Switch(ClientBase):
 #       it with HIL.
         raise NotImplementedError
 
+    @check_reserved_chars('switch')
     def delete(self, switch):
         """Deletes the switch named <switch>."""
-        self.check_reserved('switch', switch)
         url = self.object_url('switch', switch)
         return self.check_response(self.httpClient.request("DELETE", url))
 
+    @check_reserved_chars('switch')
     def show(self, switch):
         """Shows attributes of <switch>. """
-        self.check_reserved('switch', switch)
         url = self.object_url('switch', switch)
         return self.check_response(self.httpClient.request("GET", url))
 
@@ -40,49 +41,42 @@ class Switch(ClientBase):
 class Port(ClientBase):
     """Port related operations. """
 
+    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
     def register(self, switch, port):
         """Register a <port> with <switch>. """
-        self.check_reserved('switch', switch)
-        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("PUT", url))
 
+    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
     def delete(self, switch, port):
         """Deletes information of the <port> for <switch> """
-        self.check_reserved('switch', switch)
-        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("DELETE", url))
 
+    @check_reserved_chars('switch', 'port', 'node', 'nic',
+                          slashes_ok=['port'])
     def connect_nic(self, switch, port, node, nic):
         """Connects <port> of <switch> to <nic> of <node>. """
-        self.check_reserved('switch', switch)
-        self.check_reserved('port', port, slashes_ok=True)
-        self.check_reserved('node', node)
-        self.check_reserved('nic', nic)
         url = self.object_url('switch', switch, 'port', port, 'connect_nic')
         payload = json.dumps({'node': node, 'nic': nic})
         return self.check_response(
                 self.httpClient.request("POST", url, data=payload)
                 )
 
+    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
     def detach_nic(self, switch, port):
         """"Detaches <port> of <switch>. """
-        self.check_reserved('switch', switch)
-        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port, 'detach_nic')
         return self.check_response(self.httpClient.request("POST", url))
 
+    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
     def show(self, switch, port):
         """Show what's connected to <port>"""
-        self.check_reserved('switch', switch)
-        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("GET", url))
 
+    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
     def port_revert(self, switch, port):
         """removes all vlans from a switch port"""
-        self.check_reserved('switch', switch)
-        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port, 'revert')
         return self.check_response(self.httpClient.request("POST", url))

--- a/hil/client/switch.py
+++ b/hil/client/switch.py
@@ -25,13 +25,13 @@ class Switch(ClientBase):
 #       it with HIL.
         raise NotImplementedError
 
-    @check_reserved_chars('switch')
+    @check_reserved_chars()
     def delete(self, switch):
         """Deletes the switch named <switch>."""
         url = self.object_url('switch', switch)
         return self.check_response(self.httpClient.request("DELETE", url))
 
-    @check_reserved_chars('switch')
+    @check_reserved_chars()
     def show(self, switch):
         """Shows attributes of <switch>. """
         url = self.object_url('switch', switch)
@@ -41,20 +41,19 @@ class Switch(ClientBase):
 class Port(ClientBase):
     """Port related operations. """
 
-    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
+    @check_reserved_chars(slashes_ok=['port'])
     def register(self, switch, port):
         """Register a <port> with <switch>. """
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("PUT", url))
 
-    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
+    @check_reserved_chars(slashes_ok=['port'])
     def delete(self, switch, port):
         """Deletes information of the <port> for <switch> """
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("DELETE", url))
 
-    @check_reserved_chars('switch', 'port', 'node', 'nic',
-                          slashes_ok=['port'])
+    @check_reserved_chars(slashes_ok=['port'])
     def connect_nic(self, switch, port, node, nic):
         """Connects <port> of <switch> to <nic> of <node>. """
         url = self.object_url('switch', switch, 'port', port, 'connect_nic')
@@ -63,19 +62,19 @@ class Port(ClientBase):
                 self.httpClient.request("POST", url, data=payload)
                 )
 
-    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
+    @check_reserved_chars(slashes_ok=['port'])
     def detach_nic(self, switch, port):
         """"Detaches <port> of <switch>. """
         url = self.object_url('switch', switch, 'port', port, 'detach_nic')
         return self.check_response(self.httpClient.request("POST", url))
 
-    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
+    @check_reserved_chars(slashes_ok=['port'])
     def show(self, switch, port):
         """Show what's connected to <port>"""
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("GET", url))
 
-    @check_reserved_chars('switch', 'port', slashes_ok=['port'])
+    @check_reserved_chars(slashes_ok=['port'])
     def port_revert(self, switch, port):
         """removes all vlans from a switch port"""
         url = self.object_url('switch', switch, 'port', port, 'revert')

--- a/hil/client/switch.py
+++ b/hil/client/switch.py
@@ -83,6 +83,14 @@ class Port(ClientBase):
         if bool(bad_chars):
             raise BadArgumentError("Ports may not contain: %s"
                                    % bad_chars)
+        bad_chars = self.find_reserved(node)
+        if bool(bad_chars):
+            raise BadArgumentError("Nodes may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved(nic)
+        if bool(bad_chars):
+            raise BadArgumentError("Nics may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('switch', switch, 'port', port, 'connect_nic')
         payload = json.dumps({'node': node, 'nic': nic})
         return self.check_response(

--- a/hil/client/switch.py
+++ b/hil/client/switch.py
@@ -1,7 +1,6 @@
 """Client support for switch related api calls."""
 import json
 from hil.client.base import ClientBase
-from hil.errors import BadArgumentError
 
 
 class Switch(ClientBase):
@@ -27,19 +26,13 @@ class Switch(ClientBase):
 
     def delete(self, switch):
         """Deletes the switch named <switch>."""
-        bad_chars = self.find_reserved(switch)
-        if bool(bad_chars):
-            raise BadArgumentError("Switches may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('switch', switch)
         url = self.object_url('switch', switch)
         return self.check_response(self.httpClient.request("DELETE", url))
 
     def show(self, switch):
         """Shows attributes of <switch>. """
-        bad_chars = self.find_reserved(switch)
-        if bool(bad_chars):
-            raise BadArgumentError("Switches may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('switch', switch)
         url = self.object_url('switch', switch)
         return self.check_response(self.httpClient.request("GET", url))
 
@@ -49,48 +42,24 @@ class Port(ClientBase):
 
     def register(self, switch, port):
         """Register a <port> with <switch>. """
-        bad_chars = self.find_reserved(switch)
-        if bool(bad_chars):
-            raise BadArgumentError("Switches may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved_w_slash(port)
-        if bool(bad_chars):
-            raise BadArgumentError("Ports may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('switch', switch)
+        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("PUT", url))
 
     def delete(self, switch, port):
         """Deletes information of the <port> for <switch> """
-        bad_chars = self.find_reserved(switch)
-        if bool(bad_chars):
-            raise BadArgumentError("Switches may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved_w_slash(port)
-        if bool(bad_chars):
-            raise BadArgumentError("Ports may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('switch', switch)
+        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("DELETE", url))
 
     def connect_nic(self, switch, port, node, nic):
         """Connects <port> of <switch> to <nic> of <node>. """
-        bad_chars = self.find_reserved(switch)
-        if bool(bad_chars):
-            raise BadArgumentError("Switches may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved_w_slash(port)
-        if bool(bad_chars):
-            raise BadArgumentError("Ports may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(node)
-        if bool(bad_chars):
-            raise BadArgumentError("Nodes may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(nic)
-        if bool(bad_chars):
-            raise BadArgumentError("Nics may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('switch', switch)
+        self.check_reserved('port', port, slashes_ok=True)
+        self.check_reserved('node', node)
+        self.check_reserved('nic', nic)
         url = self.object_url('switch', switch, 'port', port, 'connect_nic')
         payload = json.dumps({'node': node, 'nic': nic})
         return self.check_response(
@@ -99,39 +68,21 @@ class Port(ClientBase):
 
     def detach_nic(self, switch, port):
         """"Detaches <port> of <switch>. """
-        bad_chars = self.find_reserved(switch)
-        if bool(bad_chars):
-            raise BadArgumentError("Switches may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved_w_slash(port)
-        if bool(bad_chars):
-            raise BadArgumentError("Ports may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('switch', switch)
+        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port, 'detach_nic')
         return self.check_response(self.httpClient.request("POST", url))
 
     def show(self, switch, port):
         """Show what's connected to <port>"""
-        bad_chars = self.find_reserved(switch)
-        if bool(bad_chars):
-            raise BadArgumentError("Switches may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved_w_slash(port)
-        if bool(bad_chars):
-            raise BadArgumentError("Ports may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('switch', switch)
+        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port)
         return self.check_response(self.httpClient.request("GET", url))
 
     def port_revert(self, switch, port):
         """removes all vlans from a switch port"""
-        bad_chars = self.find_reserved(switch)
-        if bool(bad_chars):
-            raise BadArgumentError("Switches may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved_w_slash(port)
-        if bool(bad_chars):
-            raise BadArgumentError("Ports may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('switch', switch)
+        self.check_reserved('port', port, slashes_ok=True)
         url = self.object_url('switch', switch, 'port', port, 'revert')
         return self.check_response(self.httpClient.request("POST", url))

--- a/hil/client/user.py
+++ b/hil/client/user.py
@@ -5,7 +5,6 @@ username & password auth.
 """
 import json
 from hil.client.base import ClientBase
-from hil.errors import BadArgumentError
 
 
 class User(ClientBase):
@@ -21,11 +20,7 @@ class User(ClientBase):
         and determines whether a user is authorized for
         administrative privileges.
         """
-
-        bad_chars = self.find_reserved(username)
-        if bool(bad_chars):
-            raise BadArgumentError("Usernames may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('username', username)
         url = self.object_url('/auth/basic/user', username)
 
         payload = json.dumps({
@@ -37,10 +32,7 @@ class User(ClientBase):
 
     def delete(self, username):
         """Deletes the user <username>. """
-        bad_chars = self.find_reserved(username)
-        if bool(bad_chars):
-            raise BadArgumentError("Usernames may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('username', username)
         url = self.object_url('/auth/basic/user', username)
         return self.check_response(
                 self.httpClient.request("DELETE", url)
@@ -48,14 +40,7 @@ class User(ClientBase):
 
     def add(self, user, project):
         """Adds <user> to a <project>. """
-        bad_chars = self.find_reserved(user)
-        if bool(bad_chars):
-            raise BadArgumentError("Usernames may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(project)
-        if bool(bad_chars):
-            raise BadArgumentError("Projects may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('user', user)
         url = self.object_url('/auth/basic/user', user, 'add_project')
         payload = json.dumps({'project': project})
         return self.check_response(
@@ -64,14 +49,8 @@ class User(ClientBase):
 
     def remove(self, user, project):
         """Removes all access of <user> to <project>. """
-        bad_chars = self.find_reserved(user)
-        if bool(bad_chars):
-            raise BadArgumentError("Usernames may not contain: %s"
-                                   % bad_chars)
-        bad_chars = self.find_reserved(project)
-        if bool(bad_chars):
-            raise BadArgumentError("Projects may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('user', user)
+        self.check_reserved('project', project)
         url = self.object_url('/auth/basic/user', user, 'remove_project')
         payload = json.dumps({'project': project})
         return self.check_response(
@@ -86,10 +65,7 @@ class User(ClientBase):
         administrative privileges.
         """
 
-        bad_chars = self.find_reserved(username)
-        if bool(bad_chars):
-            raise BadArgumentError("Usernames may not contain: %s"
-                                   % bad_chars)
+        self.check_reserved('username', username)
         url = self.object_url('/auth/basic/user', username)
         payload = json.dumps({'is_admin': is_admin})
         return self.check_response(

--- a/hil/client/user.py
+++ b/hil/client/user.py
@@ -5,6 +5,7 @@ username & password auth.
 """
 import json
 from hil.client.base import ClientBase
+from hil.errors import BadArgumentError
 
 
 class User(ClientBase):
@@ -20,6 +21,11 @@ class User(ClientBase):
         and determines whether a user is authorized for
         administrative privileges.
         """
+
+        bad_chars = self.find_reserved(username)
+        if bool(bad_chars):
+            raise BadArgumentError("Usernames may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('/auth/basic/user', username)
 
         payload = json.dumps({
@@ -31,6 +37,10 @@ class User(ClientBase):
 
     def delete(self, username):
         """Deletes the user <username>. """
+        bad_chars = self.find_reserved(username)
+        if bool(bad_chars):
+            raise BadArgumentError("Usernames may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('/auth/basic/user', username)
         return self.check_response(
                 self.httpClient.request("DELETE", url)
@@ -38,6 +48,10 @@ class User(ClientBase):
 
     def add(self, user, project):
         """Adds <user> to a <project>. """
+        bad_chars = self.find_reserved(user)
+        if bool(bad_chars):
+            raise BadArgumentError("Usernames may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('/auth/basic/user', user, 'add_project')
         payload = json.dumps({'project': project})
         return self.check_response(
@@ -46,6 +60,10 @@ class User(ClientBase):
 
     def remove(self, user, project):
         """Removes all access of <user> to <project>. """
+        bad_chars = self.find_reserved(user)
+        if bool(bad_chars):
+            raise BadArgumentError("Usernames may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('/auth/basic/user', user, 'remove_project')
         payload = json.dumps({'project': project})
         return self.check_response(
@@ -60,6 +78,10 @@ class User(ClientBase):
         administrative privileges.
         """
 
+        bad_chars = self.find_reserved(username)
+        if bool(bad_chars):
+            raise BadArgumentError("Usernames may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('/auth/basic/user', username)
         payload = json.dumps({'is_admin': is_admin})
         return self.check_response(

--- a/hil/client/user.py
+++ b/hil/client/user.py
@@ -52,6 +52,10 @@ class User(ClientBase):
         if bool(bad_chars):
             raise BadArgumentError("Usernames may not contain: %s"
                                    % bad_chars)
+        bad_chars = self.find_reserved(project)
+        if bool(bad_chars):
+            raise BadArgumentError("Projects may not contain: %s"
+                                   % bad_chars)
         url = self.object_url('/auth/basic/user', user, 'add_project')
         payload = json.dumps({'project': project})
         return self.check_response(
@@ -63,6 +67,10 @@ class User(ClientBase):
         bad_chars = self.find_reserved(user)
         if bool(bad_chars):
             raise BadArgumentError("Usernames may not contain: %s"
+                                   % bad_chars)
+        bad_chars = self.find_reserved(project)
+        if bool(bad_chars):
+            raise BadArgumentError("Projects may not contain: %s"
                                    % bad_chars)
         url = self.object_url('/auth/basic/user', user, 'remove_project')
         payload = json.dumps({'project': project})

--- a/hil/client/user.py
+++ b/hil/client/user.py
@@ -13,7 +13,7 @@ class User(ClientBase):
 
     manipulate users related objects and relations.
     """
-    @check_reserved_chars('username')
+    @check_reserved_chars(dont_check=['password', 'is_admin'])
     def create(self, username, password, is_admin):
         """Create a user <username> with password <password>.
 
@@ -30,7 +30,7 @@ class User(ClientBase):
                 self.httpClient.request("PUT", url, data=payload)
                 )
 
-    @check_reserved_chars('username')
+    @check_reserved_chars()
     def delete(self, username):
         """Deletes the user <username>. """
         url = self.object_url('/auth/basic/user', username)
@@ -38,7 +38,7 @@ class User(ClientBase):
                 self.httpClient.request("DELETE", url)
                 )
 
-    @check_reserved_chars('user', 'project')
+    @check_reserved_chars()
     def add(self, user, project):
         """Adds <user> to a <project>. """
         url = self.object_url('/auth/basic/user', user, 'add_project')
@@ -47,7 +47,7 @@ class User(ClientBase):
                 self.httpClient.request("POST", url, data=payload)
                 )
 
-    @check_reserved_chars('user', 'project')
+    @check_reserved_chars()
     def remove(self, user, project):
         """Removes all access of <user> to <project>. """
         url = self.object_url('/auth/basic/user', user, 'remove_project')
@@ -56,7 +56,7 @@ class User(ClientBase):
                 self.httpClient.request("POST", url, data=payload)
                 )
 
-    @check_reserved_chars('username')
+    @check_reserved_chars(dont_check=['is_admin'])
     def set_admin(self, username, is_admin):
         """Changes the admin status of <username>.
 

--- a/hil/client/user.py
+++ b/hil/client/user.py
@@ -5,6 +5,7 @@ username & password auth.
 """
 import json
 from hil.client.base import ClientBase
+from hil.client.base import check_reserved_chars
 
 
 class User(ClientBase):
@@ -12,7 +13,7 @@ class User(ClientBase):
 
     manipulate users related objects and relations.
     """
-
+    @check_reserved_chars('username')
     def create(self, username, password, is_admin):
         """Create a user <username> with password <password>.
 
@@ -20,7 +21,6 @@ class User(ClientBase):
         and determines whether a user is authorized for
         administrative privileges.
         """
-        self.check_reserved('username', username)
         url = self.object_url('/auth/basic/user', username)
 
         payload = json.dumps({
@@ -30,33 +30,33 @@ class User(ClientBase):
                 self.httpClient.request("PUT", url, data=payload)
                 )
 
+    @check_reserved_chars('username')
     def delete(self, username):
         """Deletes the user <username>. """
-        self.check_reserved('username', username)
         url = self.object_url('/auth/basic/user', username)
         return self.check_response(
                 self.httpClient.request("DELETE", url)
                 )
 
+    @check_reserved_chars('user', 'project')
     def add(self, user, project):
         """Adds <user> to a <project>. """
-        self.check_reserved('user', user)
         url = self.object_url('/auth/basic/user', user, 'add_project')
         payload = json.dumps({'project': project})
         return self.check_response(
                 self.httpClient.request("POST", url, data=payload)
                 )
 
+    @check_reserved_chars('user', 'project')
     def remove(self, user, project):
         """Removes all access of <user> to <project>. """
-        self.check_reserved('user', user)
-        self.check_reserved('project', project)
         url = self.object_url('/auth/basic/user', user, 'remove_project')
         payload = json.dumps({'project': project})
         return self.check_response(
                 self.httpClient.request("POST", url, data=payload)
                 )
 
+    @check_reserved_chars('username')
     def set_admin(self, username, is_admin):
         """Changes the admin status of <username>.
 
@@ -65,7 +65,6 @@ class User(ClientBase):
         administrative privileges.
         """
 
-        self.check_reserved('username', username)
         url = self.object_url('/auth/basic/user', username)
         payload = json.dumps({'is_admin': is_admin})
         return self.check_response(

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -6,6 +6,7 @@ from hil.test_common import config_testsuite, config_merge, \
     fresh_database, fail_on_log_warnings, server_init
 from hil.model import db
 from hil import config, deferred
+from hil.errors import BadArgumentError
 
 import json
 import pytest
@@ -311,6 +312,10 @@ class Test_node:
                 u'name': u'node-07'
                 }
 
+    def test_show_node_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.show('node-/%]07')
+
     def test_power_cycle(self):
         """(successful) to node_power_cycle"""
         assert C.node.power_cycle('node-07') is None
@@ -328,9 +333,17 @@ class Test_node:
         with pytest.raises(FailedAPICallException):
             C.node.power_cycle('node-07', 'wrong')
 
+    def test_power_cycle_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.power_cycle('node-/%]07', False)
+
     def test_power_off(self):
         """(successful) to node_power_off"""
         assert C.node.power_off('node-07') is None
+
+    def test_power_off_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.power_off('node-/%]07')
 
     def test_node_add_nic(self):
         """Test removing and then adding a nic."""
@@ -349,6 +362,10 @@ class Test_node:
         with pytest.raises(FailedAPICallException):
             C.node.add_nic('abcd', 'eth0', 'aa:bb:cc:dd:ee:ff')
 
+    def test_add_nic_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.add_nic('node-/%]08', 'eth0', 'aa:bb:cc:dd:ee:ff')
+
     def test_remove_nic(self):
         """(successful) call to node_remove_nic"""
         assert C.node.remove_nic('node-08', 'eth0') is None
@@ -359,13 +376,25 @@ class Test_node:
         with pytest.raises(FailedAPICallException):
             C.node.remove_nic('node-08', 'eth0')
 
+    def test_remove_nic_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.remove_nic('node-/%]08', 'eth0')
+
     def test_node_start_console(self):
         """(successful) call to node_start_console"""
         assert C.node.start_console('node-01') is None
 
+    def test_node_start_console_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.start_console('node-/%]01')
+
     def test_node_stop_console(self):
         """(successful) call to node_stop_console"""
         assert C.node.stop_console('node-01') is None
+
+    def test_node_stop_console_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.stop_console('node-/%]01')
 
     def test_node_connect_network(self):
         """(successful) call to node_connect_network"""
@@ -382,6 +411,11 @@ class Test_node:
             C.node.connect_network('node-02', 'eth0', 'net-04', 'vlan/native')
         deferred.apply_networking()
 
+    def test_node_connect_network_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.connect_network('node-/%]01', 'eth0', 'net-01',
+                                   'vlan/native')
+
     def test_node_detach_network(self):
         """(successful) call to node_detach_network"""
         C.node.connect_network('node-04', 'eth0', 'net-04', 'vlan/native')
@@ -397,6 +431,10 @@ class Test_node:
         deferred.apply_networking()
         with pytest.raises(FailedAPICallException):
             C.node.detach_network('node-04', 'eth0', 'net-04')
+
+    def test_node_detach_network_reserved_chars(self):
+        with pytest.raises(BadArgumentError):
+            C.node.detach_network('node-/%]04', 'eth0', 'net-04')
 
 
 class Test_project:

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -313,6 +313,7 @@ class Test_node:
                 }
 
     def test_show_node_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.show('node-/%]07')
 
@@ -334,6 +335,7 @@ class Test_node:
             C.node.power_cycle('node-07', 'wrong')
 
     def test_power_cycle_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.power_cycle('node-/%]07', False)
 
@@ -342,6 +344,7 @@ class Test_node:
         assert C.node.power_off('node-07') is None
 
     def test_power_off_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.power_off('node-/%]07')
 
@@ -363,6 +366,7 @@ class Test_node:
             C.node.add_nic('abcd', 'eth0', 'aa:bb:cc:dd:ee:ff')
 
     def test_add_nic_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.add_nic('node-/%]08', 'eth0', 'aa:bb:cc:dd:ee:ff')
 
@@ -377,6 +381,7 @@ class Test_node:
             C.node.remove_nic('node-08', 'eth0')
 
     def test_remove_nic_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.remove_nic('node-/%]08', 'eth0')
 
@@ -385,6 +390,7 @@ class Test_node:
         assert C.node.start_console('node-01') is None
 
     def test_node_start_console_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.start_console('node-/%]01')
 
@@ -393,6 +399,7 @@ class Test_node:
         assert C.node.stop_console('node-01') is None
 
     def test_node_stop_console_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.stop_console('node-/%]01')
 
@@ -412,6 +419,7 @@ class Test_node:
         deferred.apply_networking()
 
     def test_node_connect_network_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.connect_network('node-/%]01', 'eth0', 'net-01',
                                    'vlan/native')
@@ -433,6 +441,7 @@ class Test_node:
             C.node.detach_network('node-04', 'eth0', 'net-04')
 
     def test_node_detach_network_reserved_chars(self):
+        """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.detach_network('node-/%]04', 'eth0', 'net-04')
 
@@ -449,11 +458,21 @@ class Test_project:
         assert C.project.nodes_in('proj-01') == [u'node-01']
         assert C.project.nodes_in('proj-02') == [u'node-02', u'node-04']
 
+    def test_list_nodes_inproject_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.project.nodes_in('pr/%[oj-01')
+
     def test_list_networks_inproject(self):
         """ test for getting list of networks connected to a project. """
         assert C.project.networks_in('proj-01') == [
                 u'net-01', u'net-02', u'net-03'
                 ]
+
+    def test_list_networks_inproject_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.project.networks_in('pr/%[oj-01')
 
     def test_project_create(self):
         """ test for creating project. """
@@ -465,6 +484,11 @@ class Test_project:
         with pytest.raises(FailedAPICallException):
             C.project.create('dummy-02')
 
+    def test_project_create_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.project.create('dummy/%[-02')
+
     def test_project_delete(self):
         """ test for deleting project. """
         C.project.create('dummy-03')
@@ -474,6 +498,11 @@ class Test_project:
         """ test to capture error condition in project delete. """
         with pytest.raises(FailedAPICallException):
             C.project.delete('dummy-03')
+
+    def test_project_delete_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.project.delete('dummy/%[-03')
 
     def test_project_connect_node(self):
         """ test for connecting node to project. """
@@ -495,6 +524,11 @@ class Test_project:
         with pytest.raises(FailedAPICallException):
             C.project.connect('no-such-project', 'node-06')
 
+    def test_project_connect_node_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.project.connect('proj/%[-04', 'node-07')
+
     def test_project_detach_node(self):
         """ Test for correctly detaching node from project."""
         C.project.create('proj-07')
@@ -508,6 +542,11 @@ class Test_project:
             C.project.detach('proj-08', 'no-such-node')
         with pytest.raises(FailedAPICallException):
             C.project.detach('no-such-project', 'node-06')
+
+    def test_project_detach_node_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.project.detach('proj/%]-08', 'node-07')
 
 
 class Test_switch:
@@ -525,9 +564,19 @@ class Test_switch:
             u'name': u'dell-01', u'ports': [],
             u'capabilities': ['nativeless-trunk-mode']}
 
+    def test_show_switch_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.switch.show('dell-/%]-01')
+
     def test_delete_switch(self):
         """(successful) call to switch_delete"""
         assert C.switch.delete('nexus-01') is None
+
+    def test_delete_switch_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.switch.delete('nexus/%]-01')
 
 
 class Test_port:
@@ -543,6 +592,11 @@ class Test_port:
         with pytest.raises(FailedAPICallException):
             C.port.register('mock-01', 'gi1/1/2')
 
+    def test_port_register_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.port.register('mock-/%[-01', 'gi1/1/1')
+
     def test_port_delete(self):
         """(successful) call to port_delete"""
         C.port.register('mock-01', 'gi1/1/3')
@@ -554,6 +608,11 @@ class Test_port:
         C.port.delete('mock-01', 'gi1/1/4')
         with pytest.raises(FailedAPICallException):
             C.port.delete('mock-01', 'gi1/1/4')
+
+    def test_port_delete_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.port.delete('mock/%]-01', 'gi1/1/4')
 
     def test_port_connect_nic(self):
         """(successfully) Call port_connect_nic on an existent port"""
@@ -575,6 +634,11 @@ class Test_port:
         with pytest.raises(FailedAPICallException):
             C.port.connect_nic('mock-01', 'gi1/1/6', 'node-09', 'eth0')
 
+    def test_port_connect_nic_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.port.connect_nic('mock/%]-01', 'gi1/1/6', 'node-09', 'eth0')
+
     def test_port_detach_nic(self):
         """(succesfully) call port_detach_nic."""
         C.port.register('mock-01', 'gi1/1/7')
@@ -586,6 +650,11 @@ class Test_port:
         C.port.register('mock-01', 'gi1/1/8')
         with pytest.raises(FailedAPICallException):
             C.port.detach_nic('mock-01', 'gi1/1/8')
+
+    def test_port_detach_nic_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.port.detach_nic('mock/%]-01', 'gi1/1/8')
 
     def test_show_port(self):
         """Test show_port"""
@@ -605,6 +674,11 @@ class Test_port:
         with pytest.raises(FailedAPICallException):
             C.port.show('unknown-switch', 'unknown-port')
 
+    def test_show_port_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.port.show('mock/%]-01', 'gi1/1/8')
+
     def test_port_revert(self):
         """Revert port should run without error and remove all networks"""
         C.node.connect_network('node-01', 'eth0', 'net-01', 'vlan/native')
@@ -619,6 +693,11 @@ class Test_port:
                 'node': 'node-01',
                 'nic': 'eth0',
                 'networks': {}}
+
+    def test_port_revert_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.port.port_revert('mock/%]-01', 'gi1/0/1')
 
 
 class Test_user:
@@ -635,6 +714,11 @@ class Test_user:
         with pytest.raises(FailedAPICallException):
             C.user.create('bill', 'pass1234', is_admin=False)
 
+    def test_user_create_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.user.create('b/%]ill', 'pass1234', is_admin=True)
+
     def test_user_delete(self):
         """ Test user deletion. """
         C.user.create('jack', 'pass1234', is_admin=True)
@@ -646,6 +730,11 @@ class Test_user:
         C.user.delete('Ata')
         with pytest.raises(FailedAPICallException):
             C.user.delete('Ata')
+
+    def test_user_delete_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.user.delete('A/%]ta')
 
     def test_user_add(self):
         """ test adding a user to a project. """
@@ -660,6 +749,11 @@ class Test_user:
         C.user.add('sam01', 'test-proj01')
         with pytest.raises(FailedAPICallException):
             C.user.add('sam01', 'test-proj01')
+
+    def test_user_add_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.user.add('sam/%]01', 'test-proj01')
 
     def test_user_remove(self):
         """Test revoking user's access to a project. """
@@ -677,6 +771,11 @@ class Test_user:
         C.user.remove('sam03', 'test-proj03')
         with pytest.raises(FailedAPICallException):
             C.user.remove('sam03', 'test_proj03')
+
+    def test_user_remove_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.user.remove('sam/%]03', 'test-proj03')
 
     def test_user_set_admin(self):
         """Test changing a user's admin status """
@@ -698,6 +797,11 @@ class Test_user:
         C.user.delete('hugo')
         with pytest.raises(FailedAPICallException):
             C.user.set_admin('hugo', True)
+
+    def test_user_set_admin_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.user.set_admin('hugo/%]', True)
 
 
 class Test_network:
@@ -723,6 +827,11 @@ class Test_network:
                 u'connected-nodes': {},
                 }
 
+    def test_network_show_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.network.show('net/%]-01')
+
     def test_network_create(self):
         """ Test create network. """
         assert C.network.create('net-abcd', 'proj-01', 'proj-01', '') is None
@@ -732,6 +841,11 @@ class Test_network:
         C.network.create('net-123', 'proj-01', 'proj-01', '')
         with pytest.raises(FailedAPICallException):
             C.network.create('net-123', 'proj-01', 'proj-01', '')
+
+    def test_network_create_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.network.create('net/%]-123', 'proj-01', 'proj-01', '')
 
     def test_network_delete(self):
         """ Test network deletion """
@@ -745,6 +859,11 @@ class Test_network:
         with pytest.raises(FailedAPICallException):
             C.network.delete('net-xyz')
 
+    def test_network_delete_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.network.delete('net/%]-xyz')
+
     def test_network_grant_project_access(self):
         """ Test granting  a project access to a network. """
         C.network.create('newnet01', 'admin', '', '')
@@ -757,6 +876,11 @@ class Test_network:
         C.network.grant_access('proj-02', 'newnet04')
         with pytest.raises(FailedAPICallException):
             C.network.grant_access('proj-02', 'newnet04')
+
+    def test_network_grant_project_access_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.network.grant_access('proj/%]-02', 'newnet04')
 
     def test_network_revoke_project_access(self):
         """ Test revoking a project's access to a network. """
@@ -773,6 +897,11 @@ class Test_network:
         C.network.revoke_access('proj-02', 'newnet03')
         with pytest.raises(FailedAPICallException):
             C.network.revoke_access('proj-02', 'newnet03')
+
+    def test_network_revoke_project_access_reserved_chars(self):
+        """ test for catching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.network.revoke_access('proj/%]-02', 'newnet03')
 
 
 class Test_extensions:


### PR DESCRIPTION
This code aims to stop the `Unexpected error: No JSON object could be decoded` error mentioned in #910:
- The error is caused by 404 pages without JSON hitting `json.loads()`.
- If `json.loads()` fails, print out the response content rather than throwing the error above.
- Since this isn't pretty, the following target 404's:
    - Characters that get passed to the API will be limited to numbers, letters, and `$ - _ . + ! * ' ( ) ,`
    - The client library checks object names per-call for characters that don't match this.
- If the client library detects bad characters, it will print something like: `Error: Projects may not contain: ['/', '&']` to alert the user of the illegal characters that they entered.

 I anticipate that the tests will take a while to write since I am introducing changes to the majority of the client library calls.  Thus, I'm introducing this code now so I can get feedback before writing the tests.

Note: some commands, such as `switch_register`, have not been implemented in the client library yet.   These will get checks for reserved characters when they are implemented.