### PR TITLE
List public networks as a regular user

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -246,13 +246,16 @@ Returns a JSON dictionary of dictionaries, where the exterior dictionary is inde
 the network name and the value of each key is another dictionary with keys corresponding
 to that network's id and projects
 
+Response contains all networks if having the administrative access. Otherwise, response
+only contains all public networks.
+
 The response must contain the following fields:
 
 * "network", the name of a network
 * "network_id", the id of the network
 * "projects", a list of projects with access to the network or 'None' if network is public
 
-Example Response by an admin user:
+Example Response for an admin user:
 
     {
         "netA": {
@@ -265,7 +268,7 @@ Example Response by an admin user:
         }
     }
 
-Example Response by a regular user:
+Example Response for a regular user:
 
     {
         "netA": {

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -240,7 +240,7 @@ default channel, the VLAN drivers choose `vlan/native`.
 
 `GET /networks`
 
-List all networks.
+List all networks or List all public networks.
 
 Returns a JSON dictionary of dictionaries, where the exterior dictionary is indexed by
 the network name and the value of each key is another dictionary with keys corresponding
@@ -267,7 +267,10 @@ Example Response:
 
 Authorization requirements:
 
-* Administrative access is required
+* Administrative access is required to list all networks
+* No special access is required to list all public networks
+
+
 
 #### list_network_attachments
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -240,7 +240,7 @@ default channel, the VLAN drivers choose `vlan/native`.
 
 `GET /networks`
 
-List all networks. (Admin-level operation)
+List all networks or list all public networks
 
 Returns a JSON dictionary of dictionaries, where the exterior dictionary is indexed by
 the network name and the value of each key is another dictionary with keys corresponding
@@ -252,7 +252,7 @@ The response must contain the following fields:
 * "network_id", the id of the network
 * "projects", a list of projects with access to the network or 'None' if network is public
 
-Example Response:
+Example Response by an admin user:
 
     {
         "netA": {
@@ -265,25 +265,7 @@ Example Response:
         }
     }
 
-Authorization requirements:
-
-* Administrative access is required to list all networks
-
-`GET /networks`
-
-List all public networks. (Regular user operation)
-
-Returns a JSON dictionary of dictionaries, where the exterior dictionary is indexed by
-the network name and the value of each key is another dictionary with keys corresponding
-to that network's id and projects
-
-The response must contain the following fields:
-
-* "network", the name of a network
-* "network_id", the id of the network
-* "projects", a list of projects with access to the network or 'None' if network is public
-
-Example Response:
+Example Response by a regular user:
 
     {
         "netA": {
@@ -298,6 +280,7 @@ Example Response:
 
 Authorization requirements:
 
+* Administrative access is required to list all networks
 * No special access is required to list all public networks
 
 #### list_network_attachments

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -240,7 +240,7 @@ default channel, the VLAN drivers choose `vlan/native`.
 
 `GET /networks`
 
-List all networks or list all public networks
+List all networks or list all public networks.
 
 Returns a JSON dictionary of dictionaries, where the exterior dictionary is indexed by
 the network name and the value of each key is another dictionary with keys corresponding
@@ -269,11 +269,11 @@ Example Response by a regular user:
 
     {
         "netA": {
-            "network_id": "101",
+            "network_id": "102",
             "projects": None
         },
         "netB": {
-            "network_id": "102",
+            "network_id": "103",
             "projects": None
         }
     }

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -240,7 +240,7 @@ default channel, the VLAN drivers choose `vlan/native`.
 
 `GET /networks`
 
-List all networks or list all public networks.
+List all networks.
 
 Returns a JSON dictionary of dictionaries, where the exterior dictionary is indexed by
 the network name and the value of each key is another dictionary with keys corresponding

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -240,7 +240,7 @@ default channel, the VLAN drivers choose `vlan/native`.
 
 `GET /networks`
 
-List all networks or List all public networks.
+List all networks. (Admin-level operation)
 
 Returns a JSON dictionary of dictionaries, where the exterior dictionary is indexed by
 the network name and the value of each key is another dictionary with keys corresponding
@@ -268,9 +268,37 @@ Example Response:
 Authorization requirements:
 
 * Administrative access is required to list all networks
+
+`GET /networks`
+
+List all public networks. (Regular user operation)
+
+Returns a JSON dictionary of dictionaries, where the exterior dictionary is indexed by
+the network name and the value of each key is another dictionary with keys corresponding
+to that network's id and projects
+
+The response must contain the following fields:
+
+* "network", the name of a network
+* "network_id", the id of the network
+* "projects", a list of projects with access to the network or 'None' if network is public
+
+Example Response:
+
+    {
+        "netA": {
+            "network_id": "101",
+            "projects": None
+        },
+        "netB": {
+            "network_id": "102",
+            "projects": None
+        }
+    }
+
+Authorization requirements:
+
 * No special access is required to list all public networks
-
-
 
 #### list_network_attachments
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -246,7 +246,7 @@ Returns a JSON dictionary of dictionaries, where the exterior dictionary is inde
 the network name and the value of each key is another dictionary with keys corresponding
 to that network's id and projects
 
-Response contains all networks if having the administrative access. Otherwise, response
+Response contains all networks if the user is an admin. Otherwise, response
 only contains all public networks.
 
 The response must contain the following fields:

--- a/hil/api.py
+++ b/hil/api.py
@@ -704,9 +704,9 @@ def list_networks():
     # Regular User Operation
     else:
         pub_nets = db.session.query(model.Network).filter_by(owner=None).all()
-            if n in pub_nets:
-                net = {'network_id': n.network_id, 'projects': None}
-            result[n.label] = net
+        if n in pub_nets:
+            net = {'network_id': n.network_id, 'projects': None}
+        result[n.label] = net
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -690,10 +690,10 @@ def headnode_detach_network(headnode, hnic):
 @rest_call('GET', '/networks', Schema({}))
 def list_networks():
     """Lists all networks"""
+    networks = db.session.query(model.Network).all()
+    result = {}
     # Admin Operation
     if get_auth_backend().have_admin():
-        networks = db.session.query(model.Network).all()
-        result = {}
         for n in networks:
             if n.access:
                 net = {'network_id': n.network_id,
@@ -703,10 +703,7 @@ def list_networks():
             result[n.label] = net
     # Regular User Operation
     else:
-        networks = db.session.query(model.Network).all()
         pub_nets = db.session.query(model.Network).filter_by(owner=None).all()
-        result = {}
-
         # nasty double for loooooop. Refactor?
         for n in networks:
             if n.access:

--- a/hil/api.py
+++ b/hil/api.py
@@ -699,13 +699,13 @@ def list_networks():
                 result[n.label] = {'network_id': n.network_id,
                                    'projects': sorted([p.label for p in n.access])}
             else:
-                result[n.label] = {'network_id': n.network_id, 
+                result[n.label] = {'network_id': n.network_id,
                                    'projects': None}
     # Regular User Operation
     else:
         pub_nets = db.session.query(model.Network).filter_by(access=None).all()
         for n in pub_nets:
-            result[n.label] = {'network_id': n.network_id, 
+            result[n.label] = {'network_id': n.network_id,
                                'projects': None}
 
     return json.dumps(result, sort_keys=True)

--- a/hil/api.py
+++ b/hil/api.py
@@ -704,18 +704,9 @@ def list_networks():
     # Regular User Operation
     else:
         pub_nets = db.session.query(model.Network).filter_by(owner=None).all()
-        # nasty double for loooooop. Refactor?
-        for n in networks:
-            if n.access:
-                for proj in n.access:
-                    if get_auth_backend().have_project_access(proj):
-                        net = {'network_id': n.network_id,
-                               'projects': sorted([p.label for p in n.access])}
-                        result[n.label] = net
-            else:
-                if n in pub_nets:
-                    net = {'network_id': n.network_id, 'projects': None}
-                result[n.label] = net
+            if n in pub_nets:
+                net = {'network_id': n.network_id, 'projects': None}
+            result[n.label] = net
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -705,8 +705,9 @@ def list_networks():
     else:
         pub_nets = db.session.query(model.Network).filter_by(owner=None).all()
         for n in pub_nets:
-            net = {'network_id': n.network_id, 'projects': None}
-        result[n.label] = net
+            if not n.access:
+                net = {'network_id': n.network_id, 'projects': None}
+                result[n.label] = net
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -699,14 +699,12 @@ def list_networks():
                 net = {'network_id': n.network_id,
                        'projects': sorted([p.label for p in n.access])}
             else:
-                net = {'network_id': n.network_id, 'projects': None}
-            result[n.label] = net
+                result[n.label] = {'network_id': n.network_id, 'projects': None}
     # Regular User Operation
     else:
         pub_nets = db.session.query(model.Network).filter_by(access=None).all()
         for n in pub_nets:
-            net = {'network_id': n.network_id, 'projects': None}
-            result[n.label] = net
+            result[n.label] = {'network_id': n.network_id, 'projects': None}
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -696,8 +696,9 @@ def list_networks():
         networks = db.session.query(model.Network).all()
         for n in networks:
             if n.access:
-                result[n.label] = {'network_id': n.network_id, 
-                                   'projects': sorted([p.label for p in n.access])}
+                projects = sorted([p.label for p in n.access])
+                result[n.label] = {'network_id': n.network_id,
+                                   'projects': projects}
             else:
                 result[n.label] = {'network_id': n.network_id,
                                    'projects': None}

--- a/hil/api.py
+++ b/hil/api.py
@@ -686,18 +686,15 @@ def list_networks():
     # Admin Operation
     if get_auth_backend().have_admin():
         networks = db.session.query(model.Network).all()
-        for n in networks:
-            if n.access:
-                projects = sorted([p.label for p in n.access])
-                result[n.label] = {'network_id': n.network_id,
-                                   'projects': projects}
-            else:
-                result[n.label] = {'network_id': n.network_id,
-                                   'projects': None}
-    # Regular User Operation
     else:
-        pub_nets = db.session.query(model.Network).filter_by(access=None).all()
-        for n in pub_nets:
+        networks = db.session.query(model.Network).filter_by(access=None).all()
+
+    for n in networks:
+        if n.access:
+            projects = sorted([p.label for p in n.access])
+            result[n.label] = {'network_id': n.network_id,
+                               'projects': projects}
+        else:
             result[n.label] = {'network_id': n.network_id,
                                'projects': None}
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -704,7 +704,7 @@ def list_networks():
     # Regular User Operation
     else:
         pub_nets = db.session.query(model.Network).filter_by(owner=None).all()
-        if n in pub_nets:
+        for n in pub_nets:
             net = {'network_id': n.network_id, 'projects': None}
         result[n.label] = net
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -690,10 +690,10 @@ def headnode_detach_network(headnode, hnic):
 @rest_call('GET', '/networks', Schema({}))
 def list_networks():
     """Lists all networks"""
-    networks = db.session.query(model.Network).all()
     result = {}
     # Admin Operation
     if get_auth_backend().have_admin():
+        networks = db.session.query(model.Network).all()
         for n in networks:
             if n.access:
                 net = {'network_id': n.network_id,
@@ -703,11 +703,10 @@ def list_networks():
             result[n.label] = net
     # Regular User Operation
     else:
-        pub_nets = db.session.query(model.Network).filter_by(owner=None).all()
+        pub_nets = db.session.query(model.Network).filter_by(access=None).all()
         for n in pub_nets:
-            if not n.access:
-                net = {'network_id': n.network_id, 'projects': None}
-                result[n.label] = net
+            net = {'network_id': n.network_id, 'projects': None}
+            result[n.label] = net
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -696,7 +696,7 @@ def list_networks():
         networks = db.session.query(model.Network).all()
         for n in networks:
             if n.access:
-                net = {'network_id': n.network_id,
+                result[n.label] = {'network_id': n.network_id,
                        'projects': sorted([p.label for p in n.access])}
             else:
                 result[n.label] = {'network_id': n.network_id, 'projects': None}

--- a/hil/api.py
+++ b/hil/api.py
@@ -696,7 +696,7 @@ def list_networks():
         networks = db.session.query(model.Network).all()
         for n in networks:
             if n.access:
-                result[n.label] = {'network_id': n.network_id,
+                result[n.label] = {'network_id': n.network_id, 
                                    'projects': sorted([p.label for p in n.access])}
             else:
                 result[n.label] = {'network_id': n.network_id,

--- a/hil/api.py
+++ b/hil/api.py
@@ -697,14 +697,16 @@ def list_networks():
         for n in networks:
             if n.access:
                 result[n.label] = {'network_id': n.network_id,
-                       'projects': sorted([p.label for p in n.access])}
+                                   'projects': sorted([p.label for p in n.access])}
             else:
-                result[n.label] = {'network_id': n.network_id, 'projects': None}
+                result[n.label] = {'network_id': n.network_id, 
+                                   'projects': None}
     # Regular User Operation
     else:
         pub_nets = db.session.query(model.Network).filter_by(access=None).all()
         for n in pub_nets:
-            result[n.label] = {'network_id': n.network_id, 'projects': None}
+            result[n.label] = {'network_id': n.network_id, 
+                               'projects': None}
 
     return json.dumps(result, sort_keys=True)
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -704,7 +704,7 @@ def list_networks():
     # Regular User Operation
     else:
         networks = db.session.query(model.Network).all()
-        public_networks = db.session.query(model.Network).filter_by(owner=None).all()
+        pub_nets = db.session.query(model.Network).filter_by(owner=None).all()
         result = {}
 
         # nasty double for loooooop. Refactor?
@@ -716,7 +716,7 @@ def list_networks():
                                'projects': sorted([p.label for p in n.access])}
                         result[n.label] = net
             else:
-                if n in public_networks:
+                if n in pub_nets:
                     net = {'network_id': n.network_id, 'projects': None}
                 result[n.label] = net
 

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -1750,7 +1750,7 @@ class TestQuery_populated_db:
             'stock_ext_pub': {'projects': None},
             'stock_int_pub': {'projects': None},
         }
-        #Test against the Admin user
+        # Test against the Admin user
         auth.set_admin(True)
         admin_result = json.loads(api.list_networks())
         for net in admin_result.keys():

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -1740,10 +1740,22 @@ class TestQuery_populated_db:
 
     def test_list_networks(self):
         """Test list_networks."""
-        result = json.loads(api.list_networks())
-        for net in result.keys():
-            del result[net]['network_id']
-        assert result == {
+        auth = get_auth_backend()
+        auth.set_admin(False)
+        user_result = json.loads(api.list_networks())
+        for net in user_result.keys():
+            del user_result[net]['network_id']
+        assert user_result == {
+            'pub_default': {'projects': None},
+            'stock_ext_pub': {'projects': None},
+            'stock_int_pub': {'projects': None},
+        }
+        #Test against the Admin user
+        auth.set_admin(True)
+        admin_result = json.loads(api.list_networks())
+        for net in admin_result.keys():
+            del admin_result[net]['network_id']
+        assert admin_result == {
             'manhattan_provider': {'projects': ['manhattan']},
             'manhattan_pxe': {'projects': ['manhattan']},
             'manhattan_runway_provider': {'projects': ['manhattan', 'runway']},


### PR DESCRIPTION
## Description

Currently, only the `admin` user can list networks. This patch adds the functionality that allows a regular user to list all public networks. Any feedback and suggestion of code revise is more than welcome.

The definition of public networks:

1. Public networks with which has no project associated.
2. Networks associated with the user’s Projects.
3. Networks associated with the projects that the user is added.

This PR fixes: https://github.com/CCI-MOC/hil/issues/765
## Checklist before merging Pull Requests
- [x] New test(s) included reproducing the verify the feature
- [x] CI
- [x] Documentation
- [ ] Reviewed and approved by at least two other contributor.