### PR TITLE
API for node_register

### DIFF
--- a/hil/cli.py
+++ b/hil/cli.py
@@ -432,29 +432,7 @@ def node_register(node, subtype, *args):
         if obm is of type: ipmi then provide arguments
         "ipmi", <hostname>, <ipmi-username>, <ipmi-password>
     """
-    obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
-    obm_types = ["ipmi", "mock"]
-    # Currently the classes are hardcoded
-    # In principle this should come from api.py
-    # In future an api call to list which plugins are active will be added.
-
-    if subtype in obm_types:
-        if len(args) == 3:
-            obminfo = {"type": obm_api + subtype, "host": args[0],
-                       "user": args[1], "password": args[2]
-                       }
-        else:
-            sys.stderr.write('ERROR: subtype ' + subtype +
-                             ' requires exactly 3 arguments\n')
-            sys.stderr.write('<hostname> <ipmi-username> <ipmi-password>\n')
-            return
-    else:
-        sys.stderr.write('ERROR: Wrong OBM subtype supplied\n')
-        sys.stderr.write('Supported OBM sub-types: ipmi, mock\n')
-        return
-
-    url = object_url('node', node)
-    do_put(url, data={"obm": obminfo})
+    C.node.register(node, subtype, *args)
 
 
 @cmd

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -47,8 +47,7 @@ class Node(ClientBase):
                        "user": args[1], "password": args[2]
                        }
         else:
-            raise UnknownSubtypeError("Unknown subtype provided.
-                                      Please check your local settings")
+            raise UnknownSubtypeError("Unknown subtype provided.")
 
         url = self.object_url('node', node)
         payload = json.dumps({"obm": obminfo})

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -32,7 +32,27 @@ class Node(ClientBase):
         # and currently active drivers for HIL
         # obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
         # obm_types = ["ipmi", "mock"]
-        raise NotImplementedError
+        obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
+        obm_types = ["ipmi", "mock"]
+        if subtype in obm_types:
+            if len(args) == 3:
+                obminfo = {"type": obm_api + subtype, "host": args[0],
+                           "user": args[1], "password": args[2]
+                           }
+            else:
+                sys.stderr.write('ERROR: subtype ' + subtype +
+                                 ' requires exactly 3 arguments\n')
+                sys.stderr.write('<hostname> <ipmi-username> <ipmi-password>\n')
+                return
+        else:
+            sys.stderr.write('ERROR: Wrong OBM subtype supplied\n')
+            sys.stderr.write('Supported OBM sub-types: ipmi, mock\n')
+            return
+        url = self.object_url('node', node)
+        payload = json.dumps({"obm": obminfo})
+	return self.check_response(
+                self.httpClient.request('PUT', url, data=payload)
+                )
 
     def delete(self, node_name):
         """Deletes the node from database. """

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -43,6 +43,10 @@ class Node(ClientBase):
                 obminfo = {"type": obm_api + subtype, "host": args[0],
                            "user": args[1], "password": args[2]
                            }
+        else:
+            raise Exception('ERROR: subtype ' + subtype +
+                            ' requires exactly 3 arguments\n')
+
         url = self.object_url('node', node)
         payload = json.dumps({"obm": obminfo})
         return self.check_response(

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -1,10 +1,8 @@
 """Client support for node related api calls."""
 import json
 from hil.client.base import ClientBase
-from hil.errors import BadArgumentError
-from hil.errors import UnknownSubtypeError
 from hil.client.base import check_reserved_chars
-
+from hil.errors import BadArgumentError, UnknownSubtypeError
 
 class Node(ClientBase):
     """Consists of calls to query and manipulate node related

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -1,6 +1,8 @@
 """Client support for node related api calls."""
 import json
 from hil.client.base import ClientBase
+from hil.errors import BadArgumentError
+from hil.errors import InactiveSubtypeError
 
 
 class Node(ClientBase):
@@ -32,18 +34,19 @@ class Node(ClientBase):
         # and currently active drivers for HIL
         # obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
         # obm_types = ["ipmi", "mock"]
+        if (len(args) != 3):
+            raise BadArgumentError
+
         obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
         # This is a temp fix. obmd will let node_register no longer
         # need a type so a new design will be required.
         obm_types = ["ipmi", "mock"]
         if subtype in obm_types:
-            try:
-                obminfo = {"type": obm_api + subtype, "host": args[0],
-                           "user": args[1], "password": args[2]
-                           }
-            except Exception:
-                raise Exception('ERROR: subtype ' + subtype +
-                                ' requires exactly 3 arguments')
+            obminfo = {"type": obm_api + subtype, "host": args[0],
+                       "user": args[1], "password": args[2]
+                       }
+        else:
+            raise InactiveSubtypeError
 
         url = self.object_url('node', node)
         payload = json.dumps({"obm": obminfo})

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -34,12 +34,10 @@ class Node(ClientBase):
         # obm_types = ["ipmi", "mock"]
         obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
         ext_url = self.object_url('active_extensions')
-        ext_resp = self.check_response(self.httpClient.request("GET", ext_url))
-        obm_types = []
-        for resp in ext_resp:
-            if "hil.ext.obm" in resp:
-                obm_types.append(resp.split(".")[-1])
-
+        # This is a temp fix. obmd will let node_register no longer
+        # need a type so a new design will be required.
+        obm_types = ["ipmi", "mock"]
+        
         if subtype in obm_types:
             if len(args) == 3:
                 obminfo = {"type": obm_api + subtype, "host": args[0],

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -33,17 +33,15 @@ class Node(ClientBase):
         # obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
         # obm_types = ["ipmi", "mock"]
         obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
-        ext_url = self.object_url('active_extensions')
         # This is a temp fix. obmd will let node_register no longer
         # need a type so a new design will be required.
         obm_types = ["ipmi", "mock"]
-        
         if subtype in obm_types:
             try:
                 obminfo = {"type": obm_api + subtype, "host": args[0],
                            "user": args[1], "password": args[2]
                            }
-            except:
+            except Exception:
                 raise Exception('ERROR: subtype ' + subtype +
                                 ' requires exactly 3 arguments')
 

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -35,7 +35,8 @@ class Node(ClientBase):
         # obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
         # obm_types = ["ipmi", "mock"]
         if (len(args) != 3):
-            raise BadArgumentError
+            raise BadArgumentError("3 Arguments needed. Supplied " +
+                                   str(len(args)))
 
         obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
         # This is a temp fix. obmd will let node_register no longer

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -47,7 +47,7 @@ class Node(ClientBase):
                            }
         url = self.object_url('node', node)
         payload = json.dumps({"obm": obminfo})
-	return self.check_response(
+        return self.check_response(
                 self.httpClient.request('PUT', url, data=payload)
                 )
 

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -33,21 +33,18 @@ class Node(ClientBase):
         # obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
         # obm_types = ["ipmi", "mock"]
         obm_api = "http://schema.massopencloud.org/haas/v0/obm/"
-        obm_types = ["ipmi", "mock"]
+        ext_url = self.object_url('active_extensions')
+        ext_resp = self.check_response(self.httpClient.request("GET", ext_url))
+        obm_types = []
+        for resp in ext_resp:
+            if "hil.ext.obm" in resp:
+                obm_types.append(resp.split(".")[-1])
+
         if subtype in obm_types:
             if len(args) == 3:
                 obminfo = {"type": obm_api + subtype, "host": args[0],
                            "user": args[1], "password": args[2]
                            }
-            else:
-                sys.stderr.write('ERROR: subtype ' + subtype +
-                                 ' requires exactly 3 arguments\n')
-                sys.stderr.write('<hostname> <ipmi-username> <ipmi-password>\n')
-                return
-        else:
-            sys.stderr.write('ERROR: Wrong OBM subtype supplied\n')
-            sys.stderr.write('Supported OBM sub-types: ipmi, mock\n')
-            return
         url = self.object_url('node', node)
         payload = json.dumps({"obm": obminfo})
 	return self.check_response(

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -39,13 +39,13 @@ class Node(ClientBase):
         obm_types = ["ipmi", "mock"]
         
         if subtype in obm_types:
-            if len(args) == 3:
+            try:
                 obminfo = {"type": obm_api + subtype, "host": args[0],
                            "user": args[1], "password": args[2]
                            }
-        else:
-            raise Exception('ERROR: subtype ' + subtype +
-                            ' requires exactly 3 arguments\n')
+            except:
+                raise Exception('ERROR: subtype ' + subtype +
+                                ' requires exactly 3 arguments')
 
         url = self.object_url('node', node)
         payload = json.dumps({"obm": obminfo})

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -4,6 +4,7 @@ from hil.client.base import ClientBase
 from hil.client.base import check_reserved_chars
 from hil.errors import BadArgumentError, UnknownSubtypeError
 
+
 class Node(ClientBase):
     """Consists of calls to query and manipulate node related
 

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -2,7 +2,7 @@
 import json
 from hil.client.base import ClientBase
 from hil.errors import BadArgumentError
-from hil.errors import InactiveSubtypeError
+from hil.errors import UnknownSubtypeError
 
 
 class Node(ClientBase):
@@ -47,7 +47,8 @@ class Node(ClientBase):
                        "user": args[1], "password": args[2]
                        }
         else:
-            raise InactiveSubtypeError
+            raise UnknownSubtypeError("Unknown subtype provided.
+                                      Please check your local settings")
 
         url = self.object_url('node', node)
         payload = json.dumps({"obm": obminfo})

--- a/hil/errors.py
+++ b/hil/errors.py
@@ -63,7 +63,7 @@ class BadArgumentError(APIError):
     """An exception indicating an invalid request on the part of the user."""
 
 
-class InactiveSubtypeError(APIError):
+class UnknownSubtypeError(APIError):
     """An exception indicating an invalid request of subtypes
     on the part of the user.
     """

--- a/hil/errors.py
+++ b/hil/errors.py
@@ -63,6 +63,10 @@ class BadArgumentError(APIError):
     """An exception indicating an invalid request on the part of the user."""
 
 
+class InactiveSubtypeError(APIError):
+    """An exception indicating an invalid request of subtypes on the part of the user."""
+
+
 class ProjectMismatchError(APIError):
     """An exception indicating that the resources given don't belong to the
     same project.

--- a/hil/errors.py
+++ b/hil/errors.py
@@ -64,7 +64,9 @@ class BadArgumentError(APIError):
 
 
 class InactiveSubtypeError(APIError):
-    """An exception indicating an invalid request of subtypes on the part of the user."""
+    """An exception indicating an invalid request of subtypes
+    on the part of the user.
+    """
 
 
 class ProjectMismatchError(APIError):

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -1,7 +1,7 @@
 """Unit tests for client library"""
 from hil.flaskapp import app
 from hil.client.base import ClientBase, FailedAPICallException
-from hil.errors import BadArgumentError
+from hil.errors import BadArgumentError, UnknownSubtypeError
 from hil.client.client import Client, HTTPClient, HTTPResponse
 from hil.test_common import config_testsuite, config_merge, \
     fresh_database, fail_on_log_warnings, server_init, uuid_pattern
@@ -307,6 +307,9 @@ class Test_node:
             C.node.register("dummy-node-03", "mock",
                             "dummy", "dummy", "dummy",
                             "dummy")
+        with pytest.raises(UnknownSubtypeError):
+            C.node.register("dummy-node-04", "donotexist",
+                            "dummy", "dummy", "dummy")
 
     def test_show_node(self):
         """(successful) to show_node"""

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -297,7 +297,7 @@ class Test_node:
 
     def test_node_register(self):
         """(successful) to node_register"""
-        assert C.node.register("dummy-node-01", "mock", 
+        assert C.node.register("dummy-node-01", "mock",
                 "dummy", "dummy", "dummy") is None
 
     def test_show_node(self):

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -295,6 +295,11 @@ class Test_node:
                 u'node-06', u'node-07', u'node-08', u'node-09'
                 ]
 
+    def test_node_register(self):
+        """(successful) to node_register"""
+        assert C.node.register("dummy-node-01", "mock", 
+                "dummy", "dummy", "dummy") is None
+
     def test_show_node(self):
         """(successful) to show_node"""
         assert C.node.show('node-07') == {

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -297,7 +297,7 @@ class Test_node:
                 ]
 
     def test_node_register(self):
-        """(successful) to call node_register"""
+        """Test node_register"""
         assert C.node.register("dummy-node-01", "mock",
                                "dummy", "dummy", "dummy") is None
         with pytest.raises(BadArgumentError):

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -7,7 +7,6 @@ from hil.test_common import config_testsuite, config_merge, \
     fresh_database, fail_on_log_warnings, server_init, uuid_pattern
 from hil.model import db
 from hil import config, deferred
-from hil.errors import BadArgumentError
 
 import json
 import pytest

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -1,6 +1,7 @@
 """Unit tests for client library"""
 from hil.flaskapp import app
 from hil.client.base import ClientBase, FailedAPICallException
+from hil.errors import BadArgumentError
 from hil.client.client import Client, HTTPClient, HTTPResponse
 from hil.test_common import config_testsuite, config_merge, \
     fresh_database, fail_on_log_warnings, server_init, uuid_pattern
@@ -296,9 +297,16 @@ class Test_node:
                 ]
 
     def test_node_register(self):
-        """(successful) to node_register"""
+        """(successful) to call node_register"""
         assert C.node.register("dummy-node-01", "mock",
                                "dummy", "dummy", "dummy") is None
+        with pytest.raises(BadArgumentError):
+            C.node.register("dummy-node-02", "mock",
+                            "dummy", "dummy")
+        with pytest.raises(BadArgumentError):
+            C.node.register("dummy-node-03", "mock",
+                            "dummy", "dummy", "dummy",
+                            "dummy")
 
     def test_show_node(self):
         """(successful) to show_node"""

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -298,7 +298,7 @@ class Test_node:
     def test_node_register(self):
         """(successful) to node_register"""
         assert C.node.register("dummy-node-01", "mock",
-                "dummy", "dummy", "dummy") is None
+                               "dummy", "dummy", "dummy") is None
 
     def test_show_node(self):
         """(successful) to show_node"""


### PR DESCRIPTION
This patch adds the API function for `node_register`. The `cli` code change accordingly.

Currently, `obm_types = ["ipmi", "mock"]` is a hardcoded variable. A discussion is needed on whether or not to keep the hardcoded variable.

Any idea/suggestion/opinion/ is more than welcome.

Consider this is a WIP.

This relates to the issue: https://github.com/CCI-MOC/hil/issues/924

