### PR TITLE
Mass Open Cloud administrative updates

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright 2013-2016 Massachusetts Open Cloud Contributors (see AUTHORS).
+Copyright 2013-2018 Mass Open Cloud Contributors (see AUTHORS).
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Other work that has involved HIL can be found on the Mass Open Cloud `papers pag
 Mass Open Cloud
 ===============
 
-This project is part of the larger `Massachusetts Open Cloud
+This project is part of the larger `Mass Open Cloud
 <https://massopen.cloud/>`_. For a description of the team and other
 information, see
 `<https://github.com/CCI-MOC/moc-public/blob/master/README.md>`_.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -82,7 +82,7 @@ Documentation
 Mass Open Cloud
 ----------------
 
-This project is part of the larger `Massachusetts Open Cloud
+This project is part of the larger `Mass Open Cloud
 <http://www.massopencloud.org>`_. For a description of the team and other
 information, see
 `<https://github.com/CCI-MOC/moc-public/blob/master/README.md>`_.

--- a/examples/cloud-img-with-passwd/Makefile
+++ b/examples/cloud-img-with-passwd/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Massachusetts Open Cloud Contributors
+# Copyright 2014-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/examples/cloud-img-with-passwd/Makefile
+++ b/examples/cloud-img-with-passwd/Makefile
@@ -1,17 +1,3 @@
-# Copyright 2014-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 # $(distro).mk defines IMG_IN and MIRROR.
 include $(distro).mk
 

--- a/examples/cloud-img-with-passwd/centos.mk
+++ b/examples/cloud-img-with-passwd/centos.mk
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Massachusetts Open Cloud Contributors
+# Copyright 2014-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/examples/cloud-img-with-passwd/centos.mk
+++ b/examples/cloud-img-with-passwd/centos.mk
@@ -1,16 +1,2 @@
-# Copyright 2014-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 MIRROR := http://cloud.centos.org/centos/7/images/
 IMG_IN := CentOS-7-x86_64-GenericCloud-1503.qcow2

--- a/examples/cloud-img-with-passwd/ubuntu.mk
+++ b/examples/cloud-img-with-passwd/ubuntu.mk
@@ -1,16 +1,2 @@
-# Copyright 2014-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 MIRROR := http://cloud-images.ubuntu.com/trusty/current
 IMG_IN := trusty-server-cloudimg-amd64-disk1.img

--- a/examples/cloud-img-with-passwd/ubuntu.mk
+++ b/examples/cloud-img-with-passwd/ubuntu.mk
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 Massachusetts Open Cloud Contributors
+# Copyright 2014-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/hil/api.py
+++ b/hil/api.py
@@ -1,17 +1,3 @@
-# 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """This module provides the HIL service's public API.
 
 TODO: Spec out and document what sanitization is required.

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """This module implements the HIL command line tool."""
 from hil import config, server, migrations
 from hil.config import cfg

--- a/hil/config.py
+++ b/hil/config.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Load and query configuration data.
 
 This module handles loading of the hil.cfg file, and querying the options

--- a/hil/deferred.py
+++ b/hil/deferred.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Performs deferred networking actions."""
 
 from hil import model

--- a/hil/dev_support.py
+++ b/hil/dev_support.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
+# Copyright 2013-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/hil/dev_support.py
+++ b/hil/dev_support.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Utilities to aid with development."""
 
 import logging

--- a/hil/errors.py
+++ b/hil/errors.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2015 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Exceptions thrown by HIL api calls.
 
 This module defines several exceptions corresponding to specific errors.

--- a/hil/ext/network_allocators/null.py
+++ b/hil/ext/network_allocators/null.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
+# Copyright 2013-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/hil/ext/network_allocators/null.py
+++ b/hil/ext/network_allocators/null.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """A null network allocator.
 
 Network IDs are random and arbitrary. The only supported channel is "null".

--- a/hil/ext/obm/ipmi.py
+++ b/hil/ext/obm/ipmi.py
@@ -1,17 +1,3 @@
-# Copyright 2015-2016 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language
-# governing permissions and limitations under the License.
-
 """IPMI driver for implementing out of band management. """
 
 import schema

--- a/hil/ext/obm/mock.py
+++ b/hil/ext/obm/mock.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Massachusetts Open Cloud Contributors
+# Copyright 2015-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/hil/ext/obm/mock.py
+++ b/hil/ext/obm/mock.py
@@ -1,17 +1,3 @@
-# Copyright 2015-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language
-# governing permissions and limitations under the License.
-
 """MockObm driver for implementing out of band management. """
 
 from sqlalchemy import Column, String, ForeignKey

--- a/hil/ext/switches/_console.py
+++ b/hil/ext/switches/_console.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Common functionality for switches with a cisco-like console."""
 
 import logging

--- a/hil/ext/switches/_dell_base.py
+++ b/hil/ext/switches/_dell_base.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2017 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Super Class for Dell like drivers. """
 
 import re

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -1,17 +1,3 @@
-# Copyright 2016 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language
-# governing permissions and limitations under the License.
-
 """A switch driver for Brocade NOS.
 
 Uses the XML REST API for communicating with the switch.

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2017 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """A switch driver for the Dell Powerconnect 5500 series.
 
 Currently the driver uses telnet to connect to the switch's console; in

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -1,17 +1,3 @@
-# Copyright 2017 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language
-# governing permissions and limitations under the License.
-
 """A switch driver for Dell S3048-ON running Dell OS 9.
 
 Uses the XML REST API for communicating with the switch.

--- a/hil/ext/switches/mock.py
+++ b/hil/ext/switches/mock.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2015 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """A switch driver that maintains local state only.
 
 Meant for use in the test suite.

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -1,17 +1,3 @@
-
-# Copyright 2013-2017 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """A switch driver for the Dell N3000 series.
 
 Currently the driver uses telnet to connect to the switch's console; in

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language
-# governing permissions and limitations under the License.
-
 """A switch driver for the Nexus 5500
 
 Currently the driver uses telnet to connect to the switch's console; in the

--- a/hil/model.py
+++ b/hil/model.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2015 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Core database logic for HIL
 
 This module defines a number of built-in database objects used by HIL.

--- a/hil/rest.py
+++ b/hil/rest.py
@@ -1,16 +1,3 @@
-# Copyright 2014 Massachusetts Open Cloud Contributors (see AUTHORS).
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Module `rest` provides a flask application implementing a REST API.
 
 The main things of interest in this module are:

--- a/hil/test_common.py
+++ b/hil/test_common.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Misc. utilities for use in the test suite.
 
 Modules outside of the test suite are not permitted to import this module.

--- a/scripts/create_bridges
+++ b/scripts/create_bridges
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
+# Copyright 2013-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/scripts/create_bridges
+++ b/scripts/create_bridges
@@ -1,19 +1,3 @@
-#!/usr/bin/env python
-
-# Copyright 2013-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 from hil import config
 from hil.config import cfg
 from subprocess import call

--- a/scripts/hil
+++ b/scripts/hil
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
+# Copyright 2013-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/scripts/hil
+++ b/scripts/hil
@@ -1,18 +1,4 @@
 #!/usr/bin/env python
 
-# Copyright 2013-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 from hil import cli
 cli.main()

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2015 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 # pylint: disable=missing-docstring
 
 from setuptools import setup, find_packages

--- a/tests/deployment/headnodes.py
+++ b/tests/deployment/headnodes.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2015 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Unit tests for headnodes.
 
 These require an actual libvirt daemon (and full HIL setup), and are

--- a/tests/deployment/ipmi.py
+++ b/tests/deployment/ipmi.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2015 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Deployment tests for ipmi driver.
 
 These require an actual HIL setup with a real node, and are

--- a/tests/deployment/native_networks.py
+++ b/tests/deployment/native_networks.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Test various properties re: vlan native networks, on real hardware.
 
 For guidance on running these tests, see the section on deployment

--- a/tests/deployment/switch_config.py
+++ b/tests/deployment/switch_config.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2017 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Deployment tests re: switch configuration.
 
 For guidance on running these tests, see the section on deployment tests

--- a/tests/deployment/vlan_networks.py
+++ b/tests/deployment/vlan_networks.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2015 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Test various properties re: vlan tagged networks, on real hardware.
 
 For guidance on running these tests, see the section on deployment

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Unit tests for hil.api
 
 Some general notes:

--- a/tests/unit/api/port_register.py
+++ b/tests/unit/api/port_register.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2017 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Unit tests for port_register"""
 from hil import api, errors
 from hil.test_common import config_testsuite, config_merge, config, \

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Unit tests for client library"""
 from hil.flaskapp import app
 from hil.client.base import ClientBase, FailedAPICallException

--- a/tests/unit/deferred.py
+++ b/tests/unit/deferred.py
@@ -1,17 +1,3 @@
-# Copyright 2016 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language
-# governing permissions and limitations under the License.
-
 '''Functional test for deferred.py'''
 
 import pytest

--- a/tests/unit/dev_support.py
+++ b/tests/unit/dev_support.py
@@ -1,16 +1,3 @@
-# Copyright 2013-2018 Mass Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
 """Test the hil.dev_support module."""
 
 from hil.dev_support import no_dry_run

--- a/tests/unit/dev_support.py
+++ b/tests/unit/dev_support.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
+# Copyright 2013-2018 Mass Open Cloud Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the

--- a/tests/unit/ext/obm/ipmi.py
+++ b/tests/unit/ext/obm/ipmi.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Unit tests for ipmi.py"""
 import pytest
 from hil import api, errors

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -1,16 +1,3 @@
-# Copyright 2016 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language
-# governing permissions and limitations under the License.
 """Tests for the brocade switch driver"""
 
 import pytest

--- a/tests/unit/ext/switches/dellnos9.py
+++ b/tests/unit/ext/switches/dellnos9.py
@@ -1,16 +1,3 @@
-# Copyright 2017 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language
-# governing permissions and limitations under the License.
 """Unit tests for dell switches running Dell Networking OS 9 (with REST API)"""
 
 import pytest

--- a/tests/unit/model.py
+++ b/tests/unit/model.py
@@ -1,17 +1,3 @@
-# Copyright 2013-2014 Massachusetts Open Cloud Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the
-# License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS
-# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-
 """Functional tests for model.py"""
 
 # Some Notes:

--- a/tests/unit/rest.py
+++ b/tests/unit/rest.py
@@ -1,16 +1,3 @@
-# Copyright 2014 Massachusetts Open Cloud Contributors (see AUTHORS).
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Tests for hil.rest.
 
 This contains a somewhat awkward mix of unittest style classes and tests that


### PR DESCRIPTION
- [x] Docs changes from Massachusetts Open Cloud -> Mass Open Cloud

- [x] Extend the date from 2012, 2013, 2014, 2015, 2016, 2017 to 2018

- [x] Clean up the legal statement on each individual file and having a COPYING statement up-to-date.

This PR solves: https://github.com/CCI-MOC/hil/issues/933
