### PR TITLE
create() in haas/client/user.py accepts a string rather than bool for admin privilege

### DIFF
--- a/hil/cli.py
+++ b/hil/cli.py
@@ -301,7 +301,11 @@ def user_create(username, password, is_admin):
     <is_admin> may be either "admin" or "regular", and determines whether
     the user has administrative priveledges.
     """
-    C.user.create(username, password, is_admin)
+    if is_admin not in ('admin', 'regular'):
+        raise ValueError(
+            "invalid privilege type: must be either 'admin' or 'regular'."
+            )
+    C.user.create(username, password, is_admin == 'admin')
 
 
 @cmd

--- a/hil/client/user.py
+++ b/hil/client/user.py
@@ -13,21 +13,17 @@ class User(ClientBase):
     manipulate users related objects and relations.
     """
 
-    def create(self, username, password, privilege):
+    def create(self, username, password, is_admin):
         """Create a user <username> with password <password>.
 
-        <privilege> may by either "admin" or "regular",
+        <is_admin> may by either true or false,
         and determines whether a user is authorized for
         administrative privileges.
         """
         url = self.object_url('/auth/basic/user', username)
 
-        if privilege not in('admin', 'regular'):
-            raise ValueError(
-                "invalid privilege type: must be either  'admin' or 'regular'."
-                )
         payload = json.dumps({
-                'password': password, 'is_admin': privilege == 'admin',
+                'password': password, 'is_admin': is_admin,
                 })
         return self.check_response(
                 self.httpClient.request("PUT", url, data=payload)

--- a/hil/client/user.py
+++ b/hil/client/user.py
@@ -16,7 +16,7 @@ class User(ClientBase):
     def create(self, username, password, is_admin):
         """Create a user <username> with password <password>.
 
-        <is_admin> may by either true or false,
+        <is_admin> is a boolean,
         and determines whether a user is authorized for
         administrative privileges.
         """

--- a/hil/ext/auth/database.py
+++ b/hil/ext/auth/database.py
@@ -63,7 +63,7 @@ user_projects = db.Table('user_projects',
 @rest_call('PUT', '/auth/basic/user/<user>', schema=Schema({
     'user': basestring,
     'password': basestring,
-    Optional('is_admin'): bool, 
+    Optional('is_admin'): bool,
 }), dont_log=('password',))
 def user_create(user, password, is_admin=False):
     """Create user with given password.

--- a/hil/ext/auth/database.py
+++ b/hil/ext/auth/database.py
@@ -63,9 +63,9 @@ user_projects = db.Table('user_projects',
 @rest_call('PUT', '/auth/basic/user/<user>', schema=Schema({
     'user': basestring,
     'password': basestring,
-    Optional('is_admin'): bool,
+    'is_admin': bool,
 }), dont_log=('password',))
-def user_create(user, password, is_admin=False):
+def user_create(user, password, is_admin):
     """Create user with given password.
 
     If the user already exists, a DuplicateError will be raised.
@@ -76,7 +76,7 @@ def user_create(user, password, is_admin=False):
     # hil.api:
     api._assert_absent(User, user)
 
-    user = User(user, password, is_admin=is_admin)
+    user = User(user, password, is_admin)
     db.session.add(user)
     db.session.commit()
 

--- a/hil/ext/auth/database.py
+++ b/hil/ext/auth/database.py
@@ -63,9 +63,9 @@ user_projects = db.Table('user_projects',
 @rest_call('PUT', '/auth/basic/user/<user>', schema=Schema({
     'user': basestring,
     'password': basestring,
-    'is_admin': bool,
+    Optional('is_admin'): bool, 
 }), dont_log=('password',))
-def user_create(user, password, is_admin):
+def user_create(user, password, is_admin=False):
     """Create user with given password.
 
     If the user already exists, a DuplicateError will be raised.

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -602,23 +602,23 @@ class Test_user:
 
     def test_user_create(self):
         """ Test user creation. """
-        assert C.user.create('billy', 'pass1234', 'admin') is None
-        assert C.user.create('bobby', 'pass1234', 'regular') is None
+        assert C.user.create('billy', 'pass1234', True) is None
+        assert C.user.create('bobby', 'pass1234', False) is None
 
     def test_user_create_duplicate(self):
         """ Test duplicate user creation. """
-        C.user.create('bill', 'pass1234', 'regular')
+        C.user.create('bill', 'pass1234', False)
         with pytest.raises(FailedAPICallException):
-            C.user.create('bill', 'pass1234', 'regular')
+            C.user.create('bill', 'pass1234', False)
 
     def test_user_delete(self):
         """ Test user deletion. """
-        C.user.create('jack', 'pass1234', 'admin')
+        C.user.create('jack', 'pass1234', True)
         assert C.user.delete('jack') is None
 
     def test_user_delete_error(self):
         """ Test error condition in user deletion. """
-        C.user.create('Ata', 'pass1234', 'admin')
+        C.user.create('Ata', 'pass1234', True)
         C.user.delete('Ata')
         with pytest.raises(FailedAPICallException):
             C.user.delete('Ata')
@@ -626,13 +626,13 @@ class Test_user:
     def test_user_add(self):
         """ test adding a user to a project. """
         C.project.create('proj-sample')
-        C.user.create('Sam', 'pass1234', 'regular')
+        C.user.create('Sam', 'pass1234', False)
         assert C.user.add('Sam', 'proj-sample') is None
 
     def test_user_add_error(self):
         """Test error condition while granting user access to a project."""
         C.project.create('test-proj01')
-        C.user.create('sam01', 'pass1234', 'regular')
+        C.user.create('sam01', 'pass1234', False)
         C.user.add('sam01', 'test-proj01')
         with pytest.raises(FailedAPICallException):
             C.user.add('sam01', 'test-proj01')
@@ -640,15 +640,15 @@ class Test_user:
     def test_user_remove(self):
         """Test revoking user's access to a project. """
         C.project.create('test-proj02')
-        C.user.create('sam02', 'pass1234', 'regular')
+        C.user.create('sam02', 'pass1234', False)
         C.user.add('sam02', 'test-proj02')
         assert C.user.remove('sam02', 'test-proj02') is None
 
     def test_user_remove_error(self):
         """Test error condition while revoking user access to a project. """
         C.project.create('test-proj03')
-        C.user.create('sam03', 'pass1234', 'regular')
-        C.user.create('xxxx', 'pass1234', 'regular')
+        C.user.create('sam03', 'pass1234', False)
+        C.user.create('xxxx', 'pass1234', False)
         C.user.add('sam03', 'test-proj03')
         C.user.remove('sam03', 'test-proj03')
         with pytest.raises(FailedAPICallException):
@@ -656,21 +656,21 @@ class Test_user:
 
     def test_user_set_admin(self):
         """Test changing a user's admin status """
-        C.user.create('jimmy', '12345', 'regular')
-        C.user.create('jimbo', '678910', 'admin')
+        C.user.create('jimmy', '12345', False)
+        C.user.create('jimbo', '678910', True)
         assert C.user.set_admin('jimmy', True) is None
         assert C.user.set_admin('jimbo', False) is None
 
     def test_user_set_admin_demote_error(self):
         """Tests error condition while editing a user who doesn't exist. """
-        C.user.create('gary', '12345', 'admin')
+        C.user.create('gary', '12345', True)
         C.user.delete('gary')
         with pytest.raises(FailedAPICallException):
             C.user.set_admin('gary', False)
 
     def test_user_set_admin_promote_error(self):
         """Tests error condition while editing a user who doesn't exist. """
-        C.user.create('hugo', '12345', 'regular')
+        C.user.create('hugo', '12345', False)
         C.user.delete('hugo')
         with pytest.raises(FailedAPICallException):
             C.user.set_admin('hugo', True)

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -633,15 +633,15 @@ class Test_user:
         """Test error condition while granting user access to a project."""
         C.project.create('test-proj01')
         C.user.create('sam01', 'pass1234', False)
-        C.user.add('sam01', 'test-proj01', False)
+        C.user.add('sam01', 'test-proj01')
         with pytest.raises(FailedAPICallException):
-            C.user.add('sam01', 'test-proj01', False)
+            C.user.add('sam01', 'test-proj01')
 
     def test_user_remove(self):
         """Test revoking user's access to a project. """
         C.project.create('test-proj02')
         C.user.create('sam02', 'pass1234', False)
-        C.user.add('sam02', 'test-proj02', False)
+        C.user.add('sam02', 'test-proj02')
         assert C.user.remove('sam02', 'test-proj02') is None
 
     def test_user_remove_error(self):

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -602,23 +602,23 @@ class Test_user:
 
     def test_user_create(self):
         """ Test user creation. """
-        assert C.user.create('billy', 'pass1234', True) is None
-        assert C.user.create('bobby', 'pass1234', False) is None
+        assert C.user.create('billy', 'pass1234', is_admin=True) is None
+        assert C.user.create('bobby', 'pass1234', is_admin=False) is None
 
     def test_user_create_duplicate(self):
         """ Test duplicate user creation. """
-        C.user.create('bill', 'pass1234', False)
+        C.user.create('bill', 'pass1234', is_admin=False)
         with pytest.raises(FailedAPICallException):
-            C.user.create('bill', 'pass1234', False)
+            C.user.create('bill', 'pass1234', is_admin=False)
 
     def test_user_delete(self):
         """ Test user deletion. """
-        C.user.create('jack', 'pass1234', True)
+        C.user.create('jack', 'pass1234', is_admin=True)
         assert C.user.delete('jack') is None
 
     def test_user_delete_error(self):
         """ Test error condition in user deletion. """
-        C.user.create('Ata', 'pass1234', True)
+        C.user.create('Ata', 'pass1234', is_admin=True)
         C.user.delete('Ata')
         with pytest.raises(FailedAPICallException):
             C.user.delete('Ata')
@@ -626,13 +626,13 @@ class Test_user:
     def test_user_add(self):
         """ test adding a user to a project. """
         C.project.create('proj-sample')
-        C.user.create('Sam', 'pass1234', False)
+        C.user.create('Sam', 'pass1234', is_admin=False)
         assert C.user.add('Sam', 'proj-sample') is None
 
     def test_user_add_error(self):
         """Test error condition while granting user access to a project."""
         C.project.create('test-proj01')
-        C.user.create('sam01', 'pass1234', False)
+        C.user.create('sam01', 'pass1234', is_admin=False)
         C.user.add('sam01', 'test-proj01')
         with pytest.raises(FailedAPICallException):
             C.user.add('sam01', 'test-proj01')
@@ -640,15 +640,15 @@ class Test_user:
     def test_user_remove(self):
         """Test revoking user's access to a project. """
         C.project.create('test-proj02')
-        C.user.create('sam02', 'pass1234', False)
+        C.user.create('sam02', 'pass1234', is_admin=False)
         C.user.add('sam02', 'test-proj02')
         assert C.user.remove('sam02', 'test-proj02') is None
 
     def test_user_remove_error(self):
         """Test error condition while revoking user access to a project. """
         C.project.create('test-proj03')
-        C.user.create('sam03', 'pass1234', False)
-        C.user.create('xxxx', 'pass1234', False)
+        C.user.create('sam03', 'pass1234', is_admin=False)
+        C.user.create('xxxx', 'pass1234', is_admin=False)
         C.user.add('sam03', 'test-proj03')
         C.user.remove('sam03', 'test-proj03')
         with pytest.raises(FailedAPICallException):
@@ -656,21 +656,21 @@ class Test_user:
 
     def test_user_set_admin(self):
         """Test changing a user's admin status """
-        C.user.create('jimmy', '12345', False)
-        C.user.create('jimbo', '678910', True)
+        C.user.create('jimmy', '12345', is_admin=False)
+        C.user.create('jimbo', '678910', is_admin=True)
         assert C.user.set_admin('jimmy', True) is None
         assert C.user.set_admin('jimbo', False) is None
 
     def test_user_set_admin_demote_error(self):
         """Tests error condition while editing a user who doesn't exist. """
-        C.user.create('gary', '12345', True)
+        C.user.create('gary', '12345', is_admin=True)
         C.user.delete('gary')
         with pytest.raises(FailedAPICallException):
             C.user.set_admin('gary', False)
 
     def test_user_set_admin_promote_error(self):
         """Tests error condition while editing a user who doesn't exist. """
-        C.user.create('hugo', '12345', False)
+        C.user.create('hugo', '12345', is_admin=False)
         C.user.delete('hugo')
         with pytest.raises(FailedAPICallException):
             C.user.set_admin('hugo', True)

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -633,15 +633,15 @@ class Test_user:
         """Test error condition while granting user access to a project."""
         C.project.create('test-proj01')
         C.user.create('sam01', 'pass1234', False)
-        C.user.add('sam01', 'test-proj01')
+        C.user.add('sam01', 'test-proj01', False)
         with pytest.raises(FailedAPICallException):
-            C.user.add('sam01', 'test-proj01')
+            C.user.add('sam01', 'test-proj01', False)
 
     def test_user_remove(self):
         """Test revoking user's access to a project. """
         C.project.create('test-proj02')
         C.user.create('sam02', 'pass1234', False)
-        C.user.add('sam02', 'test-proj02')
+        C.user.add('sam02', 'test-proj02', False)
         assert C.user.remove('sam02', 'test-proj02') is None
 
     def test_user_remove_error(self):

--- a/tests/unit/ext/auth/database.py
+++ b/tests/unit/ext/auth/database.py
@@ -165,20 +165,20 @@ class TestUserCreateDelete(DBAuthTestCase):
     def test_new_user(self):
         """Creating a (previously absent) user should succeed."""
         api._assert_absent(self.dbauth.User, 'charlie')
-        self.dbauth.user_create('charlie', 'foo')
+        self.dbauth.user_create('charlie', 'foo', False)
 
     def test_duplicate_user(self):
         """Creating a user that already exists should fail."""
-        self.dbauth.user_create('charlie', 'secret')
+        self.dbauth.user_create('charlie', 'secret', False)
         with pytest.raises(errors.DuplicateError):
-            self.dbauth.user_create('charlie', 'password')
+            self.dbauth.user_create('charlie', 'password', False)
 
     def test_delete_user(self):
         """Try creating and deleting a user.
 
         Requests should succeed.
         """
-        self.dbauth.user_create('charlie', 'foo')
+        self.dbauth.user_create('charlie', 'foo', False)
         self.dbauth.user_delete('charlie')
 
     def test_delete_missing_user(self):
@@ -188,7 +188,7 @@ class TestUserCreateDelete(DBAuthTestCase):
 
     def test_delete_user_twice(self):
         """Test that deleting a user twice raises not found."""
-        self.dbauth.user_create('charlie', 'foo')
+        self.dbauth.user_create('charlie', 'foo', False)
         self.dbauth.user_delete('charlie')
         with pytest.raises(errors.NotFoundError):
             self.dbauth.user_delete('charlie')

--- a/tests/unit/ext/auth/database.py
+++ b/tests/unit/ext/auth/database.py
@@ -165,20 +165,20 @@ class TestUserCreateDelete(DBAuthTestCase):
     def test_new_user(self):
         """Creating a (previously absent) user should succeed."""
         api._assert_absent(self.dbauth.User, 'charlie')
-        self.dbauth.user_create('charlie', 'foo', False)
+        self.dbauth.user_create('charlie', 'foo')
 
     def test_duplicate_user(self):
         """Creating a user that already exists should fail."""
-        self.dbauth.user_create('charlie', 'secret', False)
+        self.dbauth.user_create('charlie', 'secret')
         with pytest.raises(errors.DuplicateError):
-            self.dbauth.user_create('charlie', 'password', False)
+            self.dbauth.user_create('charlie', 'password')
 
     def test_delete_user(self):
         """Try creating and deleting a user.
 
         Requests should succeed.
         """
-        self.dbauth.user_create('charlie', 'foo', False)
+        self.dbauth.user_create('charlie', 'foo')
         self.dbauth.user_delete('charlie')
 
     def test_delete_missing_user(self):
@@ -188,7 +188,7 @@ class TestUserCreateDelete(DBAuthTestCase):
 
     def test_delete_user_twice(self):
         """Test that deleting a user twice raises not found."""
-        self.dbauth.user_create('charlie', 'foo', False)
+        self.dbauth.user_create('charlie', 'foo')
         self.dbauth.user_delete('charlie')
         with pytest.raises(errors.NotFoundError):
             self.dbauth.user_delete('charlie')


### PR DESCRIPTION
This patch fixes this: https://github.com/CCI-MOC/hil/issues/795