### PR TITLE
Add list_network_attachments to the client library

### DIFF
--- a/hil/cli.py
+++ b/hil/cli.py
@@ -645,12 +645,7 @@ def list_network_attachments(network, project):
     """List nodes connected to a network
     <project> may be either "all" or a specific project name.
     """
-    url = object_url('network', network, 'attachments')
-
-    if project == "all":
-        do_get(url)
-    else:
-        do_get(url, params={'project': project})
+    print C.network.list_network_attachments(network, project)
 
 
 @cmd

--- a/hil/client/network.py
+++ b/hil/client/network.py
@@ -21,10 +21,10 @@ class Network(ClientBase):
             url = self.object_url('network', network, 'attachments')
             if project == "all":
                 return self.check_response(self.httpClient.request("GET", url))
-            else:
-                params = {'project': project}
-                return self.check_response(
-                        self.httpClient.request("GET", url, params=params))
+
+            params = {'project': project}
+            return self.check_response(
+                    self.httpClient.request("GET", url, params=params))
 
         @check_reserved_chars()
         def show(self, network):

--- a/hil/client/network.py
+++ b/hil/client/network.py
@@ -16,6 +16,17 @@ class Network(ClientBase):
             return self.check_response(self.httpClient.request("GET", url))
 
         @check_reserved_chars()
+        def list_network_attachments(self, network, project):
+            """Lists nodes connected to a network"""
+            url = self.object_url('network', network, 'attachments')
+            if project == "all":
+                return self.check_response(self.httpClient.request("GET", url))
+            else:
+                params = {'project': project}
+                return self.check_response(
+                        self.httpClient.request("GET", url, params=params))
+
+        @check_reserved_chars()
         def show(self, network):
             """Shows attributes of a network. """
             url = self.object_url('network', network)

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -842,6 +842,7 @@ class Test_network:
         assert C.network.list_network_attachments("net-01", "all") == {}
         assert C.network.list_network_attachments("net-02", "proj-01") == {}
         C.node.connect_network('node-01', 'eth0', 'net-03', 'vlan/native')
+        deferred.apply_networking()
         assert C.network.list_network_attachments("net-03", "all") == {
                 'node-01': {'project': 'proj-01',
                             'nic': 'eth0',

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -838,7 +838,7 @@ class Test_network:
                 }
 
     def test_list_network_attachments(self):
-        """ Test lsit of network attachments """
+        """ Test list of network attachments """
         assert C.network.list_network_attachments("net-01", "all") == {}
         assert C.network.list_network_attachments("net-01", "proj-01") == {}
 

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -840,7 +840,13 @@ class Test_network:
     def test_list_network_attachments(self):
         """ Test list of network attachments """
         assert C.network.list_network_attachments("net-01", "all") == {}
-        assert C.network.list_network_attachments("net-01", "proj-01") == {}
+        assert C.network.list_network_attachments("net-02", "proj-01") == {}
+        C.node.connect_network('node-01', 'eth0', 'net-03', 'vlan/native')
+        assert C.network.list_network_attachments("net-03", "all") == {
+                'node-01': {'project': 'proj-01',
+                            'nic': 'eth0',
+                            'channel': 'vlan/native'}
+                }
 
     def test_network_show(self):
         """ Test show network. """

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -838,7 +838,7 @@ class Test_network:
                 }
 
     def test_list_network_attachments(self):
-        assert C.network.list_network_attachments("net-01", None) == {}
+        """ Test lsit of network attachments """
         assert C.network.list_network_attachments("net-01", "all") == {}
         assert C.network.list_network_attachments("net-01", "proj-01") == {}
 

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -837,6 +837,11 @@ class Test_network:
                 u'net-05': {u'network_id': u'1005', u'projects': [u'proj-02']}
                 }
 
+    def test_list_network_attachments(self):
+        assert C.network.list_network_attachments("net-01", None) == {}
+        assert C.network.list_network_attachments("net-01", "all") == {}
+        assert C.network.list_network_attachments("net-01", "proj-01") == {}
+
     def test_network_show(self):
         """ Test show network. """
         assert C.network.show('net-01') == {


### PR DESCRIPTION
This patch adds the client API function for `list_network_attachments`. The CLI code change accordingly.

This relates to the issue: #924