### PR TITLE
Add unimplemented client library functions

### DIFF
--- a/hil/cli.py
+++ b/hil/cli.py
@@ -526,7 +526,7 @@ def metadata_set(node, label, value):
 @cmd
 def metadata_delete(node, label):
     """Delete metadata with <label> from a <node>"""
-    C.node.metadata_selete(node, label)
+    C.node.metadata_delete(node, label)
 
 
 @cmd

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -455,13 +455,12 @@ def node_power_off(node):
 @cmd
 def node_set_bootdev(node, dev):
     """
-    Sets <node> to boot from <dev> persistenly
+    Sets <node> to boot from <dev> persistently
 
     eg; hil node_set_bootdev dell-23 pxe
     for IPMI, dev can be set to disk, pxe, or none
     """
-    url = object_url('node', node, 'boot_device')
-    do_put(url, data={'bootdev': dev})
+    C.node.set_bootdev(node, dev)
 
 
 @cmd
@@ -521,15 +520,13 @@ def headnode_detach_network(headnode, hnic):
 @cmd
 def metadata_set(node, label, value):
     """Register metadata with <label> and <value> with <node> """
-    url = object_url('node', node, 'metadata', label)
-    do_put(url, data={'value': value})
+    C.node.metadata_set(node, label, value)
 
 
 @cmd
 def metadata_delete(node, label):
     """Delete metadata with <label> from a <node>"""
-    url = object_url('node', node, 'metadata', label)
-    do_delete(url)
+    C.node.metadata_selete(node, label)
 
 
 @cmd

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -78,6 +78,15 @@ class Node(ClientBase):
         url = self.object_url('node', node_name, 'power_off')
         return self.check_response(self.httpClient.request('POST', url))
 
+    @check_reserved_chars()
+    def set_bootdev(self, node, dev):
+        """Set <node> to boot from <dev> persistently"""
+        url = self.object_url('node', node, 'boot_device')
+        payload = json.dumps({'bootdev': dev})
+        return self.check_response(
+                self.httpClient.request('PUT', url, data=payload)
+                )
+
     @check_reserved_chars(dont_check=['macaddr'])
     def add_nic(self, node_name, nic_name, macaddr):
         """Add a <nic> to <node>"""
@@ -116,6 +125,21 @@ class Node(ClientBase):
         return self.check_response(
                 self.httpClient.request('POST', url, data=payload)
                 )
+
+    @check_reserved_chars()
+    def metadata_set(self, node, label, value):
+        """Register metadata with <label> and <value> with <node>"""
+        url = self.object_url('node', node, 'metadata', label)
+        payload = json.jumps({'value': value})
+        return self.check_response(
+                self.httpClient.request('PUT', url, data=payload)
+               )
+
+    @check_reserved_chars()
+    def metadata_delete(self, node, label):
+        """Delete metadata with <label> from a <node>"""
+        url = self.object_url('node', node, 'metadata', label)
+        return self.check_response(self.httpClient.request('DELETE', url))
 
     def show_console(self, node):
         """Display console log for <node> """

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -130,7 +130,7 @@ class Node(ClientBase):
     def metadata_set(self, node, label, value):
         """Register metadata with <label> and <value> with <node>"""
         url = self.object_url('node', node, 'metadata', label)
-        payload = json.jumps({'value': value})
+        payload = json.dumps({'value': value})
         return self.check_response(
                 self.httpClient.request('PUT', url, data=payload)
                )

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -411,7 +411,7 @@ class Test_node:
 
     def test_metadata_delete(self):
         """ test for deleting metadata from a node """
-        with pytest.raises(NotFoundError):
+        with pytest.raises(FailedAPICallException):
             C.node.metadata_delete("free_node", "EK")
         C.node.metadata_set("node-01", "EK", "pk")
         assert C.node.metadata_delete("node-01", "EK") is None

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -1,7 +1,8 @@
 """Unit tests for client library"""
 from hil.flaskapp import app
 from hil.client.base import ClientBase, FailedAPICallException
-from hil.errors import BadArgumentError, UnknownSubtypeError
+from hil.errors import BadArgumentError, UnknownSubtypeError, \
+    NotFoundError
 from hil.client.client import Client, HTTPClient, HTTPResponse
 from hil.test_common import config_testsuite, config_merge, \
     fresh_database, fail_on_log_warnings, server_init, uuid_pattern
@@ -410,7 +411,7 @@ class Test_node:
 
     def test_metadata_delete(self):
         """ test for deleting metadata from a node """
-        with pytest.raises(errors.NotFoundError):
+        with pytest.raises(NotFoundError):
             C.node.metadata_delete("free_node", "EK")
         C.node.metadata_set("node-01", "EK", "pk")
         assert C.node.metadata_delete("node-01", "EK") is None

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -363,6 +363,10 @@ class Test_node:
         with pytest.raises(BadArgumentError):
             C.node.power_off('node-/%]07')
 
+    def test_set_bootdev(self):
+        """ (successful) to node_set_bootdev """
+        assert C.node.set_bootdev("node-08", "pxe") is None
+
     def test_node_add_nic(self):
         """Test removing and then adding a nic."""
         C.node.remove_nic('node-08', 'eth0')
@@ -399,6 +403,17 @@ class Test_node:
         """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.remove_nic('node-/%]08', 'eth0')
+
+    def test_metadata_set(self):
+        """ test for registering metadata from a node """
+        assert C.node.metadata_set("node-01", "EK", "pk") is None
+
+    def test_metadata_delete(self):
+        """ test for deleting metadata from a node """
+        with pytest.raises(errors.NotFoundError):
+            C.node.metadata_delete("free_node", "EK")
+        C.node.metadata_set("node-01", "EK", "pk")
+        assert C.node.metadata_delete("node-01", "EK") is None
 
     def test_node_start_console(self):
         """(successful) call to node_start_console"""

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -1,8 +1,7 @@
 """Unit tests for client library"""
 from hil.flaskapp import app
 from hil.client.base import ClientBase, FailedAPICallException
-from hil.errors import BadArgumentError, UnknownSubtypeError, \
-    NotFoundError
+from hil.errors import BadArgumentError, UnknownSubtypeError
 from hil.client.client import Client, HTTPClient, HTTPResponse
 from hil.test_common import config_testsuite, config_merge, \
     fresh_database, fail_on_log_warnings, server_init, uuid_pattern


### PR DESCRIPTION
Last a few calls in #924 including:

`set_bootdev`
`metadata_set`
`metadata_delete`

Changes including:
`hil/cli.py`
`hil/client/node.py`
`test/unit/client.py`

No docs changes needed.