### PR TITLE
 Require setting a native vlan before adding any trunk vlans on the brocade switch (and correctly parse range of vlans)

### DIFF
--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -14,6 +14,7 @@ from hil.migrations import paths
 from hil.model import db, Switch, SwitchSession
 from hil.errors import BadArgumentError
 from hil.model import BigIntegerType
+from hil.ext.switches.common import check_native_networks
 
 paths[__name__] = join(dirname(__file__), 'migrations', 'brocade')
 
@@ -47,6 +48,10 @@ class Brocade(Switch, SwitchSession):
 
     def session(self):
         return self
+
+    def ensure_legal_operation(self, nic, op_type, channel):
+        check_native_networks(nic, op_type, channel)
+        return
 
     @staticmethod
     def validate_port_name(port):

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -51,7 +51,6 @@ class Brocade(Switch, SwitchSession):
 
     def ensure_legal_operation(self, nic, op_type, channel):
         check_native_networks(nic, op_type, channel)
-        return
 
     @staticmethod
     def validate_port_name(port):

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -14,7 +14,7 @@ from hil.migrations import paths
 from hil.model import db, Switch, SwitchSession
 from hil.errors import BadArgumentError
 from hil.model import BigIntegerType
-from hil.ext.switches.common import check_native_networks
+from hil.ext.switches.common import check_native_networks, parse_vlans
 
 paths[__name__] = join(dirname(__file__), 'migrations', 'brocade')
 
@@ -187,17 +187,8 @@ class Brocade(Switch, SwitchSession):
             match = re.search(r'(\d+(-\d+)?)(,\d+(-\d+)?)*', vlans)
             if match is None:
                 return []
-            range_str = match.group().split(',')
 
-            vlan_list = []
-            # need to interpret the ranges to numbers. e.g. 14-16 as 14,15,16
-            for num_str in range_str:
-                if '-' in num_str:
-                    num_str = num_str.split('-')
-                    for x in range(int(num_str[0]), int(num_str[1])+1):
-                        vlan_list.append(str(x))
-                else:
-                    vlan_list.append(num_str)
+            vlan_list = parse_vlans(match.group())
 
             return [('vlan/%s' % x, x) for x in vlan_list]
         except AttributeError:

--- a/hil/ext/switches/common.py
+++ b/hil/ext/switches/common.py
@@ -37,7 +37,7 @@ def check_native_networks(nic, op_type, channel):
 
 
 def parse_vlans(raw_vlans):
-    """Method that converts a comma separeted list of vlans and vlan ranges to
+    """Method that converts a comma separated list of vlans and vlan ranges to
     a list of individual vlans.
 
     raw_vlans is a string that can look like:

--- a/hil/ext/switches/common.py
+++ b/hil/ext/switches/common.py
@@ -1,5 +1,8 @@
-"""Helper methods common to all switches"""
+"""Helper methods for switches"""
 from hil.config import cfg
+from hil import model
+from hil.model import db
+from hil.errors import BlockedError
 
 
 def should_save(switch_obj):
@@ -9,3 +12,25 @@ def should_save(switch_obj):
         if not cfg.getboolean(switch_ext, 'save'):
             return False
     return True
+
+
+def check_native_networks(nic, op_type, channel):
+    """Check to ensure that native network is the first one to be added
+    and last one to be removed
+    """
+    table = model.NetworkAttachment
+    query = db.session.query(table).filter(table.nic_id == nic.id)
+
+    if channel != 'vlan/native' and op_type == 'connect' and \
+       query.filter(table.channel == 'vlan/native').count() == 0:
+        # checks if it is trying to attach a trunked network, and then in
+        # in the db see if nic does not have any networks attached natively
+        raise BlockedError("Please attach a native network first")
+    elif channel == 'vlan/native' and op_type == 'detach' and \
+            query.filter(table.channel != 'vlan/native').count() > 0:
+        # if it is detaching a network, then check in the database if there
+        # are any trunked vlans.
+        raise BlockedError("Please remove all trunked Vlans"
+                           " before removing the native vlan")
+    else:
+        return

--- a/hil/ext/switches/common.py
+++ b/hil/ext/switches/common.py
@@ -34,3 +34,24 @@ def check_native_networks(nic, op_type, channel):
                            " before removing the native vlan")
     else:
         return
+
+
+def parse_vlans(raw_vlans):
+    """Method that converts a comma separeted list of vlans and vlan ranges to
+    a list of individual vlans.
+
+    raw_vlans is a string that can look like:
+    '12,14-18,23,28,80-90' or '20' or '20,22' or '20-22'
+    """
+    range_str = raw_vlans.split(',')
+
+    vlan_list = []
+    for num_str in range_str:
+        if '-' in num_str:
+            num_str = num_str.split('-')
+            for x in range(int(num_str[0]), int(num_str[1])+1):
+                vlan_list.append(str(x))
+        else:
+            vlan_list.append(num_str)
+
+    return vlan_list

--- a/hil/ext/switches/common.py
+++ b/hil/ext/switches/common.py
@@ -32,8 +32,6 @@ def check_native_networks(nic, op_type, channel):
         # are any trunked vlans.
         raise BlockedError("Please remove all trunked Vlans"
                            " before removing the native vlan")
-    else:
-        return
 
 
 def parse_vlans(raw_vlans):

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -14,7 +14,7 @@ from hil.model import db, Switch, SwitchSession
 from hil.errors import BadArgumentError, BlockedError
 from hil.model import BigIntegerType
 from hil.network_allocator import get_network_allocator
-from hil.ext.switches.common import should_save
+from hil.ext.switches.common import should_save, check_native_networks
 
 logger = logging.getLogger(__name__)
 
@@ -51,23 +51,8 @@ class DellNOS9(Switch, SwitchSession):
         return self
 
     def ensure_legal_operation(self, nic, op_type, channel):
-        # get the network attachments for <nic> from the database
-        table = model.NetworkAttachment
-        query = db.session.query(table).filter(table.nic_id == nic.id)
-
-        if channel != 'vlan/native' and op_type == 'connect' and \
-           query.filter(table.channel == 'vlan/native').count() == 0:
-            # checks if it is trying to attach a trunked network, and then in
-            # in the db see if nic does not have any networks attached natively
-            raise BlockedError("Please attach a native network first")
-        elif channel == 'vlan/native' and op_type == 'detach' and \
-                query.filter(table.channel != 'vlan/native').count() > 0:
-            # if it is detaching a network, then check in the database if there
-            # are any trunked vlans.
-            raise BlockedError("Please remove all trunked Vlans"
-                               " before removing the native vlan")
-        else:
-            return
+        check_native_networks(nic, op_type, channel)
+        return
 
     def get_capabilities(self):
         return []

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -9,9 +9,8 @@ import re
 import requests
 import schema
 
-from hil import model
 from hil.model import db, Switch, SwitchSession
-from hil.errors import BadArgumentError, BlockedError
+from hil.errors import BadArgumentError
 from hil.model import BigIntegerType
 from hil.network_allocator import get_network_allocator
 from hil.ext.switches.common import should_save, check_native_networks
@@ -52,7 +51,6 @@ class DellNOS9(Switch, SwitchSession):
 
     def ensure_legal_operation(self, nic, op_type, channel):
         check_native_networks(nic, op_type, channel)
-        return
 
     def get_capabilities(self):
         return []

--- a/hil/ext/switches/dellnos9.py
+++ b/hil/ext/switches/dellnos9.py
@@ -13,7 +13,8 @@ from hil.model import db, Switch, SwitchSession
 from hil.errors import BadArgumentError
 from hil.model import BigIntegerType
 from hil.network_allocator import get_network_allocator
-from hil.ext.switches.common import should_save, check_native_networks
+from hil.ext.switches.common import should_save, check_native_networks, \
+ parse_vlans
 
 logger = logging.getLogger(__name__)
 
@@ -137,16 +138,8 @@ class DellNOS9(Switch, SwitchSession):
         match = re.search(r'T(\d+(-\d+)?)(,\d+(-\d+)?)*', response)
         if match is None:
             return []
-        range_str = match.group().replace('T', '').split(',')
-        vlan_list = []
-        # need to interpret the ranges to numbers. e.g. 14-18 as 14,15,16,17,18
-        for num_str in range_str:
-            if '-' in num_str:
-                num_str = num_str.split('-')
-                for x in range(int(num_str[0]), int(num_str[1])+1):
-                    vlan_list.append(str(x))
-            else:
-                vlan_list.append(num_str)
+
+        vlan_list = parse_vlans(match.group().replace('T', ''))
 
         return [('vlan/%s' % x, x) for x in vlan_list]
 

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -38,7 +38,7 @@ TRUNK_VLAN_RESPONSE = """
   <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed">  # noqa
     <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed/rspan-vlan"/>  # noqa
     <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed/vlan">  # noqa
-      <add>1,4001,4004,4025,4050</add>
+      <add>1,4001-4004,4025,4050</add>
     </vlan>
   </allowed>
   <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/tag">  # noqa
@@ -182,6 +182,8 @@ class TestBrocade(object):
                 PORT2: [('vlan/native', '10')],
                 PORT3: [('vlan/1', '1'),
                         ('vlan/4001', '4001'),
+                        ('vlan/4002', '4002'),
+                        ('vlan/4003', '4003'),
                         ('vlan/4004', '4004'),
                         ('vlan/4025', '4025'),
                         ('vlan/4050', '4050')]

--- a/tests/unit/ext/switches/common.py
+++ b/tests/unit/ext/switches/common.py
@@ -1,0 +1,48 @@
+import pytest
+
+from hil import config
+from hil.ext.switches.common import parse_vlans, should_save
+from hil.test_common import config_testsuite, config_merge
+from hil.ext.switches.brocade import Brocade
+from hil.ext.switches.dell import PowerConnect55xx
+
+
+@pytest.fixture
+def configure():
+    """Configure HIL"""
+    config_testsuite()
+    config_merge({
+        'auth': {
+            'require_authentication': 'True',
+        },
+        'extensions': {
+            'hil.ext.switches.brocade': '',
+            'hil.ext.switches.dell': '',
+        },
+        'hil.ext.switches.brocade': {
+            'save': 'True'
+        },
+        'hil.ext.switches.dell': {
+            'save': 'False'
+        }
+    })
+    config.load_extensions()
+
+
+def test_parse_vlans():
+    """Test parse_vlans"""
+    sample_inputs = ['12,14-18,23,28,80-90', '20', '20,22', '20-22']
+    assert parse_vlans('12,14') == ['12', '14']
+    assert parse_vlans('20-22') == ['20', '21', '22']
+    assert parse_vlans('1512') == ['1512']
+    assert parse_vlans('12,21-24,250,511-514') == [
+            '12', '21', '22', '23', '24', '250', '511', '512', '513', '514']
+
+
+def test_should_save(configure):
+    """Test should save method"""
+    brocade = Brocade()
+    dell = PowerConnect55xx()
+
+    assert should_save(brocade) is True
+    assert should_save(dell) is False

--- a/tests/unit/ext/switches/common.py
+++ b/tests/unit/ext/switches/common.py
@@ -1,10 +1,9 @@
+"""Unit tests for hil.ext.switches.common"""
+
 import pytest
 
 from hil import config
-from hil.ext.switches.common import parse_vlans, should_save
 from hil.test_common import config_testsuite, config_merge
-from hil.ext.switches.brocade import Brocade
-from hil.ext.switches.dell import PowerConnect55xx
 
 
 @pytest.fixture
@@ -31,7 +30,9 @@ def configure():
 
 def test_parse_vlans():
     """Test parse_vlans"""
-    sample_inputs = ['12,14-18,23,28,80-90', '20', '20,22', '20-22']
+    # Have to import the method here, otherwise anything starting with
+    # "hil.ext" pollutes the env.
+    from hil.ext.switches.common import parse_vlans
     assert parse_vlans('12,14') == ['12', '14']
     assert parse_vlans('20-22') == ['20', '21', '22']
     assert parse_vlans('1512') == ['1512']
@@ -41,6 +42,10 @@ def test_parse_vlans():
 
 def test_should_save(configure):
     """Test should save method"""
+    from hil.ext.switches.brocade import Brocade
+    from hil.ext.switches.dell import PowerConnect55xx
+    from hil.ext.switches.common import should_save
+
     brocade = Brocade()
     dell = PowerConnect55xx()
 


### PR DESCRIPTION

* Moved that fix from the dellnos9 driver to switches.common and then used it
in brocade.

* Fixes #728 

It's a work in progress because `tests/deployment/vlan_networks.py` is failing. Gotta dig into that and push a fix asap.