### PR TITLE
Remove pytest-catchlog from dependences.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,8 +92,7 @@ setup(name='hil',
                         ],
       extras_require={
           'tests': [
-                'pytest>=3.0.0,<4.0',
-                'pytest-catchlog>=1.2.2,<2.0',
+                'pytest>=3.3.0,<4.0',
                 'pytest-cov>2.0,<3.0',
                 'pytest-xdist>=1.14,<2.0',
                 'pycodestyle>=2.3.1',

--- a/tests/unit/rest.py
+++ b/tests/unit/rest.py
@@ -25,11 +25,6 @@ from hil.test_common import config_testsuite, fail_on_log_warnings
 fail_on_log_warnings = pytest.fixture(autouse=True)(fail_on_log_warnings)
 
 
-# This will get pulled in automaticaly, but if we declare it we'll get
-# better error messages if something goes wrong:
-pytest_plugins = 'pytest_catchlog'
-
-
 @pytest.fixture(autouse=True)
 def configure():
     """Set up the HIL config."""


### PR DESCRIPTION
We've been getting warnings about it having been merged into pytest
core, e.g:

https://travis-ci.org/CCI-MOC/hil/jobs/341455006#L2725

This also bumps the minimum version for pytest in our setup.py, since
the change was made in 3.3.0:

* https://docs.pytest.org/en/latest/changelog.html#id56
* https://github.com/pytest-dev/pytest/pull/2794