### PR TITLE
WIP: Save to flash on brocade switch

### DIFF
--- a/tests/deployment/switch_config.py
+++ b/tests/deployment/switch_config.py
@@ -53,17 +53,6 @@ pytestmark = pytest.mark.usefixtures('configure',
                                      'site_layout')
 
 
-@pytest.fixture
-def is_brocade():
-    """open the site-layout file to see if we have a brocade switch"""
-
-    with open('site-layout.json') as layout_data:
-        layout = json.load(layout_data)
-    switch_type = layout['switches'][0]['type']
-    return (switch_type == BROCADE)
-
-
-@pytest.mark.skipif(is_brocade(), reason="Skipping because brocade switch")
 class TestSwitchSavingToFlash(NetworkTest):
     """ saves the running config to the flash memory and tests if it succeeded
     by comparing the running and startup config files"""

--- a/tests/deployment/switch_config.py
+++ b/tests/deployment/switch_config.py
@@ -11,9 +11,6 @@ from hil.test_common import config, config_testsuite, fresh_database, \
     NetworkTest, network_create_simple, server_init
 
 import pytest
-import json
-
-BROCADE = 'http://schema.massopencloud.org/haas/v0/switches/brocade'
 
 
 @pytest.fixture
@@ -31,6 +28,9 @@ def configure():
             'save': 'True'
         },
         'hil.ext.switches.dellnos9': {
+            'save': 'True'
+        },
+        'hil.ext.switches.brocade': {
             'save': 'True'
         }
     })


### PR DESCRIPTION
* In response to issue #899 

* Please don't judge me for using pexpect for getting the startup-config file in the brocade driver. That was  the only way to do it, I figured. 

* The method `get_config()` of brocade is kinda gross right now and needs some work, but I am opening this PR to get feedback about the general approach.

* `tests/deployment/switch_config.py` passed for this.