### PR TITLE
Bug Fix: Omit coverage test in virtualenv

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,5 @@ omit =
     hil/ext/switches/_dell_base.py
     tests/unit/ext/obm/*
     tests/unit/ext/switches/*
+    # Omit Travis Virtual Env
+    /home/travis/virtualenv/*


### PR DESCRIPTION
so all files within the `virtaulenv` should not be considered when we are running the coverage test.
