### PR TITLE
Enforce unique contraints on object names/labels in the database.

### DIFF
--- a/hil/migrations/versions/264ddaebdfcc_make_labels_unique.py
+++ b/hil/migrations/versions/264ddaebdfcc_make_labels_unique.py
@@ -7,7 +7,7 @@ Create Date: 2018-03-12 11:15:09.729850
 """
 
 from alembic import op
-#import sqlalchemy as sa
+# import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/hil/migrations/versions/264ddaebdfcc_make_labels_unique.py
+++ b/hil/migrations/versions/264ddaebdfcc_make_labels_unique.py
@@ -7,7 +7,7 @@ Create Date: 2018-03-12 11:15:09.729850
 """
 
 from alembic import op
-import sqlalchemy as sa
+#import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/hil/migrations/versions/264ddaebdfcc_make_labels_unique.py
+++ b/hil/migrations/versions/264ddaebdfcc_make_labels_unique.py
@@ -1,0 +1,32 @@
+"""make labels unique
+
+Revision ID: 264ddaebdfcc
+Revises: 89ff8a6d72b2
+Create Date: 2018-03-12 11:15:09.729850
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '264ddaebdfcc'
+down_revision = '89ff8a6d72b2'
+branch_labels = ('hil')
+
+# pylint: disable=missing-docstring
+
+
+def upgrade():
+    op.create_unique_constraint(None, 'network', ['label'])
+    op.create_unique_constraint(None, 'node', ['label'])
+    op.create_unique_constraint(None, 'project', ['label'])
+    op.create_unique_constraint(None, 'switch', ['label'])
+
+
+def downgrade():
+    op.drop_constraint(None, 'switch', type_='unique')
+    op.drop_constraint(None, 'project', type_='unique')
+    op.drop_constraint(None, 'node', type_='unique')
+    op.drop_constraint(None, 'network', type_='unique')

--- a/hil/migrations/versions/264ddaebdfcc_make_labels_unique.py
+++ b/hil/migrations/versions/264ddaebdfcc_make_labels_unique.py
@@ -13,7 +13,7 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = '264ddaebdfcc'
 down_revision = '89ff8a6d72b2'
-branch_labels = ('hil')
+branch_labels = ('hil',)
 
 # pylint: disable=missing-docstring
 

--- a/hil/migrations/versions/89ff8a6d72b2_add_uuid_and_status_to_networkingaction.py
+++ b/hil/migrations/versions/89ff8a6d72b2_add_uuid_and_status_to_networkingaction.py
@@ -15,7 +15,7 @@ from hil import model
 # revision identifiers, used by Alembic.
 revision = '89ff8a6d72b2'
 down_revision = '7acb050f783c'
-branch_labels = ('hil',)
+branch_labels = None
 
 # pylint: disable=missing-docstring
 

--- a/hil/model.py
+++ b/hil/model.py
@@ -58,7 +58,7 @@ class Nic(db.Model):
     """a nic belonging to a Node"""
 
     id = db.Column(BigIntegerType, primary_key=True)
-    label = db.Column(db.String, nullable=False)
+    label = db.Column(db.String, unique=True, nullable=False)
 
     # The Node to which the nic belongs:
     owner_id = db.Column(db.ForeignKey('node.id'), nullable=False)

--- a/hil/model.py
+++ b/hil/model.py
@@ -58,7 +58,7 @@ class Nic(db.Model):
     """a nic belonging to a Node"""
 
     id = db.Column(BigIntegerType, primary_key=True)
-    label = db.Column(db.String, unique=True, nullable=False)
+    label = db.Column(db.String, nullable=False)
 
     # The Node to which the nic belongs:
     owner_id = db.Column(db.ForeignKey('node.id'), nullable=False)
@@ -81,7 +81,7 @@ class Nic(db.Model):
 class Node(db.Model):
     """a (physical) machine"""
     id = db.Column(BigIntegerType, primary_key=True)
-    label = db.Column(db.String, nullable=False)
+    label = db.Column(db.String, unique=True, nullable=False)
 
     # The project to which this node is allocated. If the project is null, the
     # node is unallocated:

--- a/hil/model.py
+++ b/hil/model.py
@@ -112,7 +112,7 @@ class Project(db.Model):
     A project may contain allocated nodes, networks, and headnodes.
     """
     id = db.Column(BigIntegerType, primary_key=True)
-    label = db.Column(db.String, nullable=False)
+    label = db.Column(db.String, unique=True, nullable=False)
 
     def __init__(self, label):
         """Create a project with the given label."""
@@ -143,7 +143,7 @@ class Network(db.Model):
     See docs/networks.md for more information on the parameters.
     """
     id = db.Column(BigIntegerType, primary_key=True)
-    label = db.Column(db.String, nullable=False)
+    label = db.Column(db.String, unique=True, nullable=False)
 
     # The project to which the network belongs, or None if the network was
     # created by the administrator.  This field determines who can delete a
@@ -205,7 +205,7 @@ class Switch(db.Model):
     Subclasses MUST override both ``validate`` and ``session``.
     """
     id = db.Column(BigIntegerType, primary_key=True)
-    label = db.Column(db.String, nullable=False)
+    label = db.Column(db.String, unique=True, nullable=False)
 
     type = db.Column(db.String, nullable=False)
 

--- a/tests/unit/deferred.py
+++ b/tests/unit/deferred.py
@@ -170,7 +170,7 @@ def switch(_deferred_test_switch_class):
 def new_nic(name):
     """Create a new nic named ``name``, and an associated Node + Obm.
     The new nic is attached to a new node each time, and the node is added to
-    the project named 'anvil-nextgen-defer' """
+    the project named 'anvil-nextgen-####' """
 
     from hil.ext.obm.mock import MockObm
     unique_id = str(uuid.uuid4())

--- a/tests/unit/deferred.py
+++ b/tests/unit/deferred.py
@@ -170,10 +170,11 @@ def switch(_deferred_test_switch_class):
 def new_nic(name):
     """Create a new nic named ``name``, and an associated Node + Obm.
     The new nic is attached to a new node each time, and the node is added to
-    the project named 'anvil-nextgen' """
+    the project named 'anvil-nextgen-defer' """
 
     from hil.ext.obm.mock import MockObm
-    project = model.Project('anvil-nextgen')
+    unique_id = str(uuid.uuid4())
+    project = model.Project('anvil-nextgen-' + unique_id)
     node = model.Node(
             label=str(uuid.uuid4()),
             obm=MockObm(

--- a/tests/unit/migrations/flask.sql
+++ b/tests/unit/migrations/flask.sql
@@ -147,7 +147,7 @@ CREATE TABLE mockswitch (
 
 CREATE TABLE network (
     id integer NOT NULL,
-    label character varying NOT NULL UNIQUE,
+    label character varying NOT NULL,
     creator_id integer,
     access_id integer,
     allocated boolean,
@@ -287,7 +287,7 @@ ALTER SEQUENCE nic_id_seq OWNED BY nic.id;
 
 CREATE TABLE node (
     id integer NOT NULL,
-    label character varying NOT NULL UNIQUE,
+    label character varying NOT NULL,
     project_id integer,
     obm_id integer NOT NULL
 );
@@ -389,7 +389,7 @@ CREATE TABLE powerconnect55xx (
 
 CREATE TABLE project (
     id integer NOT NULL,
-    label character varying NOT NULL UNIQUE
+    label character varying NOT NULL
 );
 
 
@@ -418,7 +418,7 @@ ALTER SEQUENCE project_id_seq OWNED BY project.id;
 
 CREATE TABLE switch (
     id integer NOT NULL,
-    label character varying NOT NULL UNIQUE,
+    label character varying NOT NULL,
     type character varying NOT NULL
 );
 
@@ -448,7 +448,7 @@ ALTER SEQUENCE switch_id_seq OWNED BY switch.id;
 
 CREATE TABLE "user" (
     id integer NOT NULL,
-    label character varying NOT NULL UNIQUE,
+    label character varying NOT NULL,
     is_admin boolean NOT NULL,
     hashed_password character varying
 );

--- a/tests/unit/migrations/flask.sql
+++ b/tests/unit/migrations/flask.sql
@@ -147,7 +147,7 @@ CREATE TABLE mockswitch (
 
 CREATE TABLE network (
     id integer NOT NULL,
-    label character varying NOT NULL,
+    label character varying NOT NULL UNIQUE,
     creator_id integer,
     access_id integer,
     allocated boolean,
@@ -287,7 +287,7 @@ ALTER SEQUENCE nic_id_seq OWNED BY nic.id;
 
 CREATE TABLE node (
     id integer NOT NULL,
-    label character varying NOT NULL,
+    label character varying NOT NULL UNIQUE,
     project_id integer,
     obm_id integer NOT NULL
 );
@@ -389,7 +389,7 @@ CREATE TABLE powerconnect55xx (
 
 CREATE TABLE project (
     id integer NOT NULL,
-    label character varying NOT NULL
+    label character varying NOT NULL UNIQUE
 );
 
 
@@ -418,7 +418,7 @@ ALTER SEQUENCE project_id_seq OWNED BY project.id;
 
 CREATE TABLE switch (
     id integer NOT NULL,
-    label character varying NOT NULL,
+    label character varying NOT NULL UNIQUE,
     type character varying NOT NULL
 );
 
@@ -448,7 +448,7 @@ ALTER SEQUENCE switch_id_seq OWNED BY switch.id;
 
 CREATE TABLE "user" (
     id integer NOT NULL,
-    label character varying NOT NULL,
+    label character varying NOT NULL UNIQUE,
     is_admin boolean NOT NULL,
     hashed_password character varying
 );


### PR DESCRIPTION
Fix: #946 

Potentially, we should think about whether there are any other constraints.

And this might break lots of tests. Consider this is an on-going implementation