### PR TITLE
Move show_console to the client library

### DIFF
--- a/hil/api.py
+++ b/hil/api.py
@@ -1289,7 +1289,7 @@ def show_console(nodename):
     if log is None:
         raise errors.NotFoundError(
             'The console log for %s does not exist.' % nodename)
-    return json.dumps(log)
+    return log
 
 
 @rest_call('PUT', '/node/<nodename>/console', Schema({'nodename': basestring}))

--- a/hil/api.py
+++ b/hil/api.py
@@ -1289,7 +1289,7 @@ def show_console(nodename):
     if log is None:
         raise errors.NotFoundError(
             'The console log for %s does not exist.' % nodename)
-    return log
+    return json.dumps(log)
 
 
 @rest_call('PUT', '/node/<nodename>/console', Schema({'nodename': basestring}))

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -760,6 +760,7 @@ def show_console(node):
     """Display console log for <node>"""
     C.node.show_console(node)
 
+
 @cmd
 def start_console(node):
     """Start logging console output from <node>"""

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -758,7 +758,7 @@ def list_headnode_images():
 @cmd
 def show_console(node):
     """Display console log for <node>"""
-    print C.node.show_console(node)
+    print (C.node.show_console(node))
 
 
 @cmd

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -758,9 +758,7 @@ def list_headnode_images():
 @cmd
 def show_console(node):
     """Display console log for <node>"""
-    url = object_url('node', node, 'console')
-    do_get(url)
-
+    C.node.show_console(node)
 
 @cmd
 def start_console(node):

--- a/hil/cli.py
+++ b/hil/cli.py
@@ -758,7 +758,7 @@ def list_headnode_images():
 @cmd
 def show_console(node):
     """Display console log for <node>"""
-    C.node.show_console(node)
+    print C.node.show_console(node)
 
 
 @cmd

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -141,6 +141,7 @@ class Node(ClientBase):
         url = self.object_url('node', node, 'metadata', label)
         return self.check_response(self.httpClient.request('DELETE', url))
 
+    @check_reserved_chars()
     def show_console(self, node):
         """Display console log for <node> """
         url = self.object_url('node', node, 'console')

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -143,7 +143,8 @@ class Node(ClientBase):
 
     def show_console(self, node):
         """Display console log for <node> """
-        raise NotImplementedError
+        url = self.object_url('node', node, 'console')
+        return self.check_response(self.httpClient.request('GET', url))
 
     @check_reserved_chars()
     def start_console(self, node):

--- a/hil/ext/obm/mock.py
+++ b/hil/ext/obm/mock.py
@@ -12,6 +12,8 @@ from hil.model import BigIntegerType
 
 paths[__name__] = join(dirname(__file__), 'migrations', 'mock')
 
+CONSOLE = False
+
 
 class MockObm(Obm):
     """Mock OBM object, for use in tests."""
@@ -50,22 +52,29 @@ class MockObm(Obm):
     def set_bootdev(self, dev):
         return
 
-    @no_dry_run
     def start_console(self):
+        global CONSOLE
+        CONSOLE = True
         return
 
-    @no_dry_run
     def stop_console(self):
+        global CONSOLE
+        CONSOLE = False
         return
 
     @no_dry_run
     def delete_console(self):
         return
 
-    @no_dry_run
     def get_console(self):
-        return
+        global CONSOLE
+        if CONSOLE:
+            return "Some console output"
 
     @no_dry_run
     def get_console_log_filename(self):
+        return
+
+    @no_dry_run
+    def show_console(self):
         return

--- a/hil/ext/obm/mock.py
+++ b/hil/ext/obm/mock.py
@@ -4,15 +4,15 @@ from sqlalchemy import Column, String, ForeignKey
 import schema
 
 from hil.model import Obm
-from hil.dev_support import no_dry_run
 
 from os.path import join, dirname
 from hil.migrations import paths
 from hil.model import BigIntegerType
+from collections import defaultdict
 
 paths[__name__] = join(dirname(__file__), 'migrations', 'mock')
 
-CONSOLE = False
+LOCAL_STATE = defaultdict(lambda: defaultdict(dict))
 
 
 class MockObm(Obm):
@@ -38,11 +38,9 @@ class MockObm(Obm):
             'password': basestring,
             }).validate(kwargs)
 
-    @no_dry_run
     def power_cycle(self, force):
         return
 
-    @no_dry_run
     def power_off(self):
         return
 
@@ -53,29 +51,22 @@ class MockObm(Obm):
         return
 
     def start_console(self):
-        global CONSOLE
-        CONSOLE = True
+        state = LOCAL_STATE[self.id]
+        state['console'] = True
         return
 
     def stop_console(self):
-        global CONSOLE
-        CONSOLE = False
+        state = LOCAL_STATE[self.id]
+        state['console'] = False
         return
 
-    @no_dry_run
     def delete_console(self):
         return
 
     def get_console(self):
-        global CONSOLE
-        if CONSOLE:
+        state = LOCAL_STATE[self.id]
+        if state['console']:
             return "Some console output"
 
-    @no_dry_run
     def get_console_log_filename(self):
-        return
-
-    @no_dry_run
-    def show_console(self):
-        """ return nothing for obm mock driver """
         return

--- a/hil/ext/obm/mock.py
+++ b/hil/ext/obm/mock.py
@@ -77,4 +77,5 @@ class MockObm(Obm):
 
     @no_dry_run
     def show_console(self):
+        """ return nothing for obm mock driver """
         return

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -422,7 +422,7 @@ class Test_node:
     def test_node_show_console_reserved_chars(self):
         """test for cataching illegal argument characters"""
         with pytest.raises(BadArgumentError):
-            C.node.show_console('node-/%]01') 
+            C.node.show_console('node-/%]01')
 
     def test_node_start_console(self):
         """(successful) call to node_start_console"""

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -415,6 +415,15 @@ class Test_node:
         C.node.metadata_set("node-01", "EK", "pk")
         assert C.node.metadata_delete("node-01", "EK") is None
 
+    def test_node_show_console(self):
+        """(successful) call to node_show_console"""
+        assert C.node.show_console('node-01') is None
+
+    def test_node_show_console_reserved_chars(self):
+        """test for cataching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.node.show_console('node-/%]01') 
+
     def test_node_start_console(self):
         """(successful) call to node_start_console"""
         assert C.node.start_console('node-01') is None

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -415,15 +415,6 @@ class Test_node:
         C.node.metadata_set("node-01", "EK", "pk")
         assert C.node.metadata_delete("node-01", "EK") is None
 
-    def test_node_show_console(self):
-        """(successful) call to node_show_console"""
-        assert C.node.show_console('node-01') is None
-
-    def test_node_show_console_reserved_chars(self):
-        """test for cataching illegal argument characters"""
-        with pytest.raises(BadArgumentError):
-            C.node.show_console('node-/%]01')
-
     def test_node_start_console(self):
         """(successful) call to node_start_console"""
         assert C.node.start_console('node-01') is None
@@ -432,6 +423,16 @@ class Test_node:
         """ test for catching illegal argument characters"""
         with pytest.raises(BadArgumentError):
             C.node.start_console('node-/%]01')
+
+    def test_node_show_console(self):
+        """(successful) call to node_show_console"""
+        C.node.start_console('node-01')
+        assert C.node.show_console('node-01') is None
+
+    def test_node_show_console_reserved_chars(self):
+        """test for cataching illegal argument characters"""
+        with pytest.raises(BadArgumentError):
+            C.node.show_console('node-/%]01')
 
     def test_node_stop_console(self):
         """(successful) call to node_stop_console"""

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -426,7 +426,7 @@ class Test_node:
     def test_node_show_console(self):
         """various calls to node_show_console"""
 
-        # show console without staring should fail.
+        # show console without starting should fail.
         with pytest.raises(FailedAPICallException):
             C.node.show_console('node-01')
 

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -111,7 +111,6 @@ def configure():
             'hil.ext.switches.dell': '',
             'hil.ext.switches.brocade': '',
             'hil.ext.obm.mock': '',
-            'hil.ext.obm.ipmi': '',
             'hil.ext.network_allocators.null': None,
             'hil.ext.network_allocators.vlan_pool': '',
         },
@@ -153,11 +152,11 @@ def populate_server():
 
     # Adding nodes, node-01 - node-09
     url_node = 'http://127.0.0.1:8000/node/'
-    ipmi = 'http://schema.massopencloud.org/haas/v0/obm/ipmi'
+    mock = 'http://schema.massopencloud.org/haas/v0/obm/mock'
 
     for i in range(1, 10):
         obminfo = {
-                "type": ipmi, "host": "10.10.0.0"+repr(i),
+                "type": mock, "host": "10.10.0.0"+repr(i),
                 "user": "ipmi_u", "password": "pass1234"
                 }
         http_client.request(
@@ -975,7 +974,6 @@ class Test_extensions:
         assert C.extensions.list_active() == [
                     "hil.ext.auth.database",
                     "hil.ext.network_allocators.vlan_pool",
-                    "hil.ext.obm.ipmi",
                     "hil.ext.obm.mock",
                     "hil.ext.switches.brocade",
                     "hil.ext.switches.dell",

--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -424,9 +424,18 @@ class Test_node:
             C.node.start_console('node-/%]01')
 
     def test_node_show_console(self):
-        """(successful) call to node_show_console"""
+        """various calls to node_show_console"""
+
+        # show console without staring should fail.
+        with pytest.raises(FailedAPICallException):
+            C.node.show_console('node-01')
+
         C.node.start_console('node-01')
-        assert C.node.show_console('node-01') is None
+        assert C.node.show_console('node-01') == 'Some console output'
+
+        C.node.stop_console('node-01')
+        with pytest.raises(FailedAPICallException):
+            C.node.show_console('node-01')
 
     def test_node_show_console_reserved_chars(self):
         """test for cataching illegal argument characters"""


### PR DESCRIPTION
Simply move `show_console` to the client library.

Relates to: https://github.com/CCI-MOC/hil/issues/924