### PR TITLE
Use flask_sqlalchmey instead of flask.ext.sqlalchemy

### DIFF
--- a/hil/model.py
+++ b/hil/model.py
@@ -11,7 +11,7 @@ Extensions are permitted to create new database objects by subclassing from
 # from sqlalchemy import *
 # from sqlalchemy.ext.declarative import declarative_base, declared_attr
 # from sqlalchemy.orm import relationship, sessionmaker,backref
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from subprocess import call, check_call, Popen, PIPE
 from hil.flaskapp import app
 from hil.config import cfg


### PR DESCRIPTION
* flask.ext.sqlalchemy is deperacated.
Without this, flask would keep throwing the deprecation warning
```
(.venv) naved:~/flask-warning/hil$ hil list_nodes all
/home/naved/flask-warning/hil/hil/model.py:14: ExtDeprecationWarning: Importing flask.ext.sqlalchemy is deprecated, use flask_sqlalchemy instead.
  from flask.ext.sqlalchemy import SQLAlchemy

```
We should have caught this in #977 