### PR TITLE
Use flask_script since flask.ext.script is deprecated (in admin.py)

### DIFF
--- a/hil/commands/admin.py
+++ b/hil/commands/admin.py
@@ -4,7 +4,7 @@ from hil.commands import db
 from hil.commands.migrate_ipmi_info import MigrateIpmiInfo
 from hil.commands.util import ensure_not_root
 from hil.flaskapp import app
-from flask.ext.script import Manager
+from flask_script import Manager
 
 manager = Manager(app)
 manager.add_command('db', db.command)


### PR DESCRIPTION
Change to `flask_script` based on the CLI prompt saying `flask.ext.script` is deprecated. 

```bash
(.venv) ➜ ubuntu@hil-dev  ~/hil git:(master) hil-admin db create
/home/ubuntu/hil/hil/commands/admin.py:7: ExtDeprecationWarning: Importing flask.ext.script is deprecated, use flask_script instead.
  from flask.ext.script import Manager
DEBUG:passlib.registry:registered 'sha512_crypt' handler: <class 'passlib.handlers.sha2_crypt.sha512_crypt'>
```

Similiar to https://github.com/CCI-MOC/hil/pull/981