### PR TITLE
Read inactive vlans

### DIFF
--- a/hil/ext/switches/_dell_base.py
+++ b/hil/ext/switches/_dell_base.py
@@ -36,7 +36,6 @@ class _BaseSession(_console.Session):
         self.disable_vlan(vlan_id)
         self._sendline('sw trunk native vlan none')
 
-
     def get_port_networks(self, ports):
         '''Returns every trunking VLAN and native VLAN from a port config.
         Example: Port 1 has 'Trunking Native Mode VLAN': ' 3 (Inactive)',

--- a/hil/ext/switches/_dell_base.py
+++ b/hil/ext/switches/_dell_base.py
@@ -36,6 +36,7 @@ class _BaseSession(_console.Session):
         self.disable_vlan(vlan_id)
         self._sendline('sw trunk native vlan none')
 
+
     def get_port_networks(self, ports):
         '''Returns every trunking VLAN and native VLAN from a port config.
         Example: Port 1 has 'Trunking Native Mode VLAN': ' 3 (Inactive)',

--- a/hil/ext/switches/_dell_base.py
+++ b/hil/ext/switches/_dell_base.py
@@ -58,8 +58,7 @@ class _BaseSession(_console.Session):
             # get native vlan then remove junk if native is not None
             native_vlan = v['Trunking Native Mode VLAN'].strip()
             if native_vlan != 'none':
-                native_vlan = ''.join(c for c in native_vlan
-                                      if c not in badchars)
+                native_vlan.replace(' (Inactive)', '')
                 network_list.append(('vlan/native', native_vlan))
             else:
                 native_vlan = None
@@ -73,7 +72,7 @@ class _BaseSession(_console.Session):
                 # create comma-separated list to use parse_vlans()
                 non_natives = ','.join(non_natives)
                 non_native_list = parse_vlans(non_natives)
-            for v in (non_native_list):
+            for v in non_native_list:
                 if v != native_vlan:
                     network_list.append(('vlan/%s' % v, int(v)))
         return network_list

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -8,8 +8,7 @@ import logging
 from schema import Schema, Optional
 import re
 
-from hil import model
-from hil.model import db, Switch, Port
+from hil.model import db, Switch
 from hil.migrations import paths
 from hil.ext.switches import _console
 from hil.ext.switches._dell_base import _BaseSession

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -41,9 +41,6 @@ class PowerConnect55xx(Switch):
     hostname = db.Column(db.String, nullable=False)
     username = db.Column(db.String, nullable=False)
     password = db.Column(db.String, nullable=False)
-    #hostname = '192.168.3.247'
-    #username = 'admin'
-    #password = '.bluegit4'
 
     @staticmethod
     def validate(kwargs):
@@ -107,10 +104,3 @@ class _PowerConnect55xxSession(_BaseSession):
             self._sendline('terminal datadump')
         elif lines == 'default':
             self._sendline('no terminal datadump')
-
-#switcho = PowerConnect55xx()
-#ports = [Port('gi1/0/3', switcho), Port('gi1/0/20', switcho),
-#         Port('gi1/0/21', switcho), Port('gi1/0/2', switcho)]
-#ports = [Port('gi1/0/3', switcho)]
-#print switcho.session()._port_configs(ports)
-#print switcho.session().get_port_networks(ports)

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -8,7 +8,8 @@ import logging
 from schema import Schema, Optional
 import re
 
-from hil.model import db, Switch
+from hil import model
+from hil.model import db, Switch, Port
 from hil.migrations import paths
 from hil.ext.switches import _console
 from hil.ext.switches._dell_base import _BaseSession
@@ -35,11 +36,14 @@ class PowerConnect55xx(Switch):
         'polymorphic_identity': api_name,
     }
 
-    id = db.Column(BigIntegerType,
-                   db.ForeignKey('switch.id'), primary_key=True)
-    hostname = db.Column(db.String, nullable=False)
-    username = db.Column(db.String, nullable=False)
-    password = db.Column(db.String, nullable=False)
+    #id = db.Column(BigIntegerType,
+    #               db.ForeignKey('switch.id'), primary_key=True)
+    #hostname = db.Column(db.String, nullable=False)
+    #username = db.Column(db.String, nullable=False)
+    #password = db.Column(db.String, nullable=False)
+    hostname = '192.168.3.247'
+    username = 'admin'
+    password = '.bluegit4'
 
     @staticmethod
     def validate(kwargs):
@@ -103,3 +107,10 @@ class _PowerConnect55xxSession(_BaseSession):
             self._sendline('terminal datadump')
         elif lines == 'default':
             self._sendline('no terminal datadump')
+
+switcho = PowerConnect55xx()
+ports = [Port('gi1/0/3', switcho), Port('gi1/0/20', switcho),
+         Port('gi1/0/21', switcho), Port('gi1/0/2', switcho)]
+#ports = [Port('gi1/0/3', switcho)]
+print switcho.session()._port_configs(ports)
+print switcho.session().get_port_networks(ports)

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -36,11 +36,14 @@ class PowerConnect55xx(Switch):
         'polymorphic_identity': api_name,
     }
 
-    id = db.Column(BigIntegerType,
-                   db.ForeignKey('switch.id'), primary_key=True)
-    hostname = db.Column(db.String, nullable=False)
-    username = db.Column(db.String, nullable=False)
-    password = db.Column(db.String, nullable=False)
+    #id = db.Column(BigIntegerType,
+    #               db.ForeignKey('switch.id'), primary_key=True)
+    #hostname = db.Column(db.String, nullable=False)
+    #username = db.Column(db.String, nullable=False)
+    #password = db.Column(db.String, nullable=False)
+    hostname = '192.168.3.247'
+    username = 'admin'
+    password = '.bluegit4'
 
     @staticmethod
     def validate(kwargs):
@@ -104,3 +107,10 @@ class _PowerConnect55xxSession(_BaseSession):
             self._sendline('terminal datadump')
         elif lines == 'default':
             self._sendline('no terminal datadump')
+
+switcho = PowerConnect55xx()
+ports = [Port('gi1/0/3', switcho), Port('gi1/0/20', switcho),
+         Port('gi1/0/21', switcho), Port('gi1/0/2', switcho)]
+#ports = [Port('gi1/0/3', switcho)]
+print switcho.session()._port_configs(ports)
+print switcho.session().get_port_networks(ports)

--- a/hil/ext/switches/dell.py
+++ b/hil/ext/switches/dell.py
@@ -36,14 +36,14 @@ class PowerConnect55xx(Switch):
         'polymorphic_identity': api_name,
     }
 
-    #id = db.Column(BigIntegerType,
-    #               db.ForeignKey('switch.id'), primary_key=True)
-    #hostname = db.Column(db.String, nullable=False)
-    #username = db.Column(db.String, nullable=False)
-    #password = db.Column(db.String, nullable=False)
-    hostname = '192.168.3.247'
-    username = 'admin'
-    password = '.bluegit4'
+    id = db.Column(BigIntegerType,
+                   db.ForeignKey('switch.id'), primary_key=True)
+    hostname = db.Column(db.String, nullable=False)
+    username = db.Column(db.String, nullable=False)
+    password = db.Column(db.String, nullable=False)
+    #hostname = '192.168.3.247'
+    #username = 'admin'
+    #password = '.bluegit4'
 
     @staticmethod
     def validate(kwargs):
@@ -108,9 +108,9 @@ class _PowerConnect55xxSession(_BaseSession):
         elif lines == 'default':
             self._sendline('no terminal datadump')
 
-switcho = PowerConnect55xx()
-ports = [Port('gi1/0/3', switcho), Port('gi1/0/20', switcho),
-         Port('gi1/0/21', switcho), Port('gi1/0/2', switcho)]
+#switcho = PowerConnect55xx()
+#ports = [Port('gi1/0/3', switcho), Port('gi1/0/20', switcho),
+#         Port('gi1/0/21', switcho), Port('gi1/0/2', switcho)]
 #ports = [Port('gi1/0/3', switcho)]
-print switcho.session()._port_configs(ports)
-print switcho.session().get_port_networks(ports)
+#print switcho.session()._port_configs(ports)
+#print switcho.session().get_port_networks(ports)

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -183,3 +183,35 @@ class _DellN3000Session(_BaseSession):
                 if v != native_vlan:
                     network_list.append(('vlan/%s' % v, int(v)))
         return network_list
+
+
+    def get_port_networks(self, ports):
+        port_configs = self._port_configs(ports)
+        badchars = ' (Inactive)'
+        network_list = []
+        for k, v in port_configs.iteritems():
+            non_natives = ''
+            non_native_list = []
+            # Get native vlan then remove junk if native not None
+            native_vlan = v['Trunking Native Mode VLAN'].strip()
+            if (native_vlan != 'none'):
+                native_vlan = ''.join(c for c in native_vlan
+                                      if c not in badchars)
+            else:
+                native_vlan = None
+            # Get other vlans and parse out junk if not None
+            trunk_vlans = v['Trunking VLANs Enabled'].strip()
+            if (trunk_vlans != 'none'):
+                non_natives = ''.join(c for c in trunk_vlans
+                                      if c not in badchars)
+                non_natives = non_natives.split('\r\n')
+                non_natives = ','.join(non_natives)
+                non_native_list = parse_vlans(non_natives)
+            else:
+                non_natives = None
+            if native_vlan is not None:
+                network_list.append(('vlan/native', native_vlan))
+            for v in (non_native_list):
+                if v != native_vlan:
+                    network_list.append(('vlan/%s' % v, int(v)))
+        return network_list

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -200,7 +200,7 @@ class _DellN3000Session(_BaseSession):
                 native_vlan = None
             # Get other vlans and parse out junk if not None
             trunk_vlans = v['Trunking VLANs Enabled'].strip()
-            if (trunk_vlans != 'none'):
+            if trunk_vlans != 'none':
                 non_natives = ''.join(c for c in trunk_vlans
                                       if c not in badchars)
                 non_natives = non_natives.split('\r\n')

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -152,7 +152,7 @@ class _DellN3000Session(_BaseSession):
         self.console.expect(self.main_prompt)
         return result
 
-    def get_port_networks(self, ports):
+    """def get_port_networks(self, ports):
         num_re = re.compile(r'(\d+)')
         port_configs = self._port_configs(ports)
         result = {}
@@ -183,7 +183,7 @@ class _DellN3000Session(_BaseSession):
             if native is not None:
                 networks.append(('vlan/native', native))
             result[k] = networks
-        return result
+        return result"""
 
 
     def get_port_networks(self, ports):

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -162,14 +162,14 @@ class _DellN3000Session(_BaseSession):
             non_native_list = []
             # Get native vlan then remove junk if native not None
             native_vlan = v['Trunking Native Mode VLAN'].strip()
-            if (native_vlan != 'none'):
+            if native_vlan != 'none':
                 native_vlan = ''.join(c for c in native_vlan
                                       if c not in badchars)
             else:
                 native_vlan = None
             # Get other vlans and parse out junk if not None
             trunk_vlans = v['Trunking VLANs Enabled'].strip()
-            if (trunk_vlans != 'none'):
+            if trunk_vlans != 'none':
                 non_natives = ''.join(c for c in trunk_vlans
                                       if c not in badchars)
                 non_natives = non_natives.split('\r\n')

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -184,7 +184,6 @@ class _DellN3000Session(_BaseSession):
                     network_list.append(('vlan/%s' % v, int(v)))
         return network_list
 
-
     def get_port_networks(self, ports):
         port_configs = self._port_configs(ports)
         badchars = ' (Inactive)'

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -45,9 +45,9 @@ class DellN3000(Switch):
             'username': basestring,
             'hostname': basestring,
             'password': basestring,
-            'dummy_vlan': schema.And(schema.Use(int),
-                                     lambda v: 0 < v and v <= 4093,
-                                     schema.Use(str)),
+            'dummy_vlan': And(Use(int),
+                              lambda v: 0 < v <=4093,
+                              Use(str)),
         }).validate(kwargs)
 
     def session(self):
@@ -151,39 +151,6 @@ class _DellN3000Session(_BaseSession):
         self._sendline('\n')
         self.console.expect(self.main_prompt)
         return result
-
-    """def get_port_networks(self, ports):
-        num_re = re.compile(r'(\d+)')
-        port_configs = self._port_configs(ports)
-        result = {}
-        for k, v in port_configs.iteritems():
-            native = v['Trunking Mode Native VLAN'].strip()
-            match = re.match(num_re, native)
-            if match:
-                # We need to call groups to get the part of the string that
-                # actually matched, because it could include some junk on the
-                # end, e.g. "100 (Inactive)".
-                num_str = match.groups()[0]
-                native = int(num_str)
-                if native == int(self.switch.dummy_vlan):
-                    native = None
-            else:
-                native = None
-            networks = []
-            for range_str in v['Trunking Mode VLANs Enabled'].split(','):
-                for num_str in range_str.split('-'):
-                    num_str = num_str.strip()
-                    match = re.match(num_re, num_str)
-                    if match:
-                        # There may be other tokens in the output, e.g.
-                        # the string "(Inactive)" somteimtes appears.
-                        # We should only use the value if it's an actual number
-                        num_str = match.groups()[0]
-                        networks.append(('vlan/%s' % num_str, int(num_str)))
-            if native is not None:
-                networks.append(('vlan/native', native))
-            result[k] = networks
-        return result"""
 
 
     def get_port_networks(self, ports):

--- a/hil/ext/switches/n3000.py
+++ b/hil/ext/switches/n3000.py
@@ -6,7 +6,7 @@ the long term we want to be using SNMP.
 
 import re
 import logging
-from schema import Schema, Optional, And, Use
+import schema
 
 from hil.model import db, Switch
 from hil.migrations import paths
@@ -16,13 +16,10 @@ from os.path import dirname, join
 from hil.errors import BadArgumentError
 from hil.model import BigIntegerType
 from hil.config import core_schema, string_is_bool
+from hil.ext.switches.common import parse_vlans
 
 logger = logging.getLogger(__name__)
 paths[__name__] = join(dirname(__file__), 'migrations', 'n3000')
-
-core_schema[__name__] = {
-    Optional('save'): string_is_bool
-}
 
 
 class DellN3000(Switch):
@@ -44,14 +41,13 @@ class DellN3000(Switch):
 
     @staticmethod
     def validate(kwargs):
-        """Note: Dell N3000 VLAN range only from 1 - 4093."""
-        Schema({
+        schema.Schema({
             'username': basestring,
             'hostname': basestring,
             'password': basestring,
-            'dummy_vlan': And(Use(int),
-                              lambda v: 0 < v <= 4093,
-                              Use(str)),
+            'dummy_vlan': schema.And(schema.Use(int),
+                                     lambda v: 0 < v and v <= 4093,
+                                     schema.Use(str)),
         }).validate(kwargs)
 
     def session(self):
@@ -188,3 +184,35 @@ class _DellN3000Session(_BaseSession):
                 networks.append(('vlan/native', native))
             result[k] = networks
         return result
+
+
+    def get_port_networks(self, ports):
+        port_configs = self._port_configs(ports)
+        badchars = ' (Inactive)'
+        network_list = []
+        for k, v in port_configs.iteritems():
+            non_natives = ''
+            non_native_list = []
+            # Get native vlan then remove junk if native not None
+            native_vlan = v['Trunking Native Mode VLAN'].strip()
+            if (native_vlan != 'none'):
+                native_vlan = ''.join(c for c in native_vlan
+                                      if c not in badchars)
+            else:
+                native_vlan = None
+            # Get other vlans and parse out junk if not None
+            trunk_vlans = v['Trunking VLANs Enabled'].strip()
+            if (trunk_vlans != 'none'):
+                non_natives = ''.join(c for c in trunk_vlans
+                                      if c not in badchars)
+                non_natives = non_natives.split('\r\n')
+                non_natives = ','.join(non_natives)
+                non_native_list = parse_vlans(non_natives)
+            else:
+                non_natives = None
+            if native_vlan is not None:
+                network_list.append(('vlan/native', native_vlan))
+            for v in (non_native_list):
+                if v != native_vlan:
+                    network_list.append(('vlan/%s' % v, int(v)))
+        return network_list

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -14,6 +14,7 @@ from hil.errors import BadArgumentError
 from os.path import join, dirname
 from hil.migrations import paths
 from hil.model import BigIntegerType
+<<<<<<< refs/remotes/upstream/master
 from hil.config import core_schema, string_is_bool
 from hil.ext.switches.common import parse_vlans
 
@@ -35,12 +36,16 @@ class Nexus(Switch):
         'polymorphic_identity': api_name,
     }
 
-    id = db.Column(BigIntegerType,
-                   db.ForeignKey('switch.id'), primary_key=True)
-    hostname = db.Column(db.String, nullable=False)
-    username = db.Column(db.String, nullable=False)
-    password = db.Column(db.String, nullable=False)
-    dummy_vlan = db.Column(db.String, nullable=False)
+    #id = db.Column(BigIntegerType,
+    #               db.ForeignKey('switch.id'), primary_key=True)
+    #hostname = db.Column(db.String, nullable=False)
+    #username = db.Column(db.String, nullable=False)
+    #password = db.Column(db.String, nullable=False)
+    #dummy_vlan = db.Column(db.String, nullable=False)
+    hostname = '192.168.3.230'
+    username = 'admin'
+    password = '.bluegit4'
+    dummy_vlan = 0
 
     @staticmethod
     def validate(kwargs):
@@ -246,3 +251,13 @@ class _Session(_console.Session):
     def disable_port(self):
         self._sendline('sw trunk allowed vlan none')
         self._sendline('sw trunk native vlan ' + self.dummy_vlan)
+
+
+
+switcher = Nexus()
+# test port 19 too
+ports = [Port('Ethernet1/19', switcher), Port('Ethernet1/27', switcher), Port('Ethernet1/25', switcher)]
+#ports = [Port('Ethernet1/19', switcher)]
+#ports = [Port('gi1/0/3', switcher)]
+print switcher.session()._port_configs(ports)
+print switcher.session().get_port_networks(ports)

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -14,12 +14,8 @@ from hil.errors import BadArgumentError
 from os.path import join, dirname
 from hil.migrations import paths
 from hil.model import BigIntegerType
-<<<<<<< refs/remotes/upstream/master
 from hil.config import core_schema, string_is_bool
-
-=======
 from hil.ext.switches.common import parse_vlans
->>>>>>> first pass at dell and nexus get_port_networks fix.  Need to remove debug statements
 
 logger = logging.getLogger(__name__)
 
@@ -39,16 +35,16 @@ class Nexus(Switch):
         'polymorphic_identity': api_name,
     }
 
-    #id = db.Column(BigIntegerType,
-    #               db.ForeignKey('switch.id'), primary_key=True)
-    #hostname = db.Column(db.String, nullable=False)
-    #username = db.Column(db.String, nullable=False)
-    #password = db.Column(db.String, nullable=False)
-    #dummy_vlan = db.Column(db.String, nullable=False)
-    hostname = '192.168.3.230'
-    username = 'admin'
-    password = '.bluegit4'
-    dummy_vlan = 0
+    id = db.Column(BigIntegerType,
+                   db.ForeignKey('switch.id'), primary_key=True)
+    hostname = db.Column(db.String, nullable=False)
+    username = db.Column(db.String, nullable=False)
+    password = db.Column(db.String, nullable=False)
+    dummy_vlan = db.Column(db.String, nullable=False)
+    #hostname = '192.168.3.230'
+    #username = 'admin'
+    #password = '.bluegit4'
+    #dummy_vlan = 0
 
     @staticmethod
     def validate(kwargs):
@@ -296,10 +292,10 @@ class _Session(_console.Session):
 
 
 
-switcher = Nexus()
+#switcher = Nexus()
 # test port 19 too
-ports = [Port('Ethernet1/19', switcher), Port('Ethernet1/27', switcher), Port('Ethernet1/25', switcher)]
+#ports = [Port('Ethernet1/19', switcher), Port('Ethernet1/27', switcher), Port('Ethernet1/25', switcher)]
 #ports = [Port('Ethernet1/19', switcher)]
 #ports = [Port('gi1/0/3', switcher)]
-print switcher.session()._port_configs(ports)
-print switcher.session().get_port_networks(ports)
+#print switcher.session()._port_configs(ports)
+#print switcher.session().get_port_networks(ports)

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -41,10 +41,6 @@ class Nexus(Switch):
     username = db.Column(db.String, nullable=False)
     password = db.Column(db.String, nullable=False)
     dummy_vlan = db.Column(db.String, nullable=False)
-    #hostname = '192.168.3.230'
-    #username = 'admin'
-    #password = '.bluegit4'
-    #dummy_vlan = 0
 
     @staticmethod
     def validate(kwargs):
@@ -250,13 +246,3 @@ class _Session(_console.Session):
     def disable_port(self):
         self._sendline('sw trunk allowed vlan none')
         self._sendline('sw trunk native vlan ' + self.dummy_vlan)
-
-
-
-#switcher = Nexus()
-# test port 19 too
-#ports = [Port('Ethernet1/19', switcher), Port('Ethernet1/27', switcher), Port('Ethernet1/25', switcher)]
-#ports = [Port('Ethernet1/19', switcher)]
-#ports = [Port('gi1/0/3', switcher)]
-#print switcher.session()._port_configs(ports)
-#print switcher.session().get_port_networks(ports)

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -8,7 +8,7 @@ import re
 from schema import Schema, Optional, And, Use
 import logging
 
-from hil.model import db, Switch, Port
+from hil.model import db, Switch
 from hil.ext.switches import _console
 from hil.errors import BadArgumentError
 from os.path import join, dirname
@@ -179,12 +179,10 @@ class _Session(_console.Session):
 
         return result
 
-
     def get_port_networks(self, ports):
         port_configs = self._port_configs(ports)
         network_list = []
-        for k, v in port_configs.iteritems():
-            non_natives = ''
+        for _, v in port_configs.iteritems():
             non_native_list = []
             # Get native vlan then remove junk if native not None
             native_vlan = v['Trunking Native Mode VLAN'].strip()
@@ -198,8 +196,6 @@ class _Session(_console.Session):
             trunk_vlans = v['Trunking VLANs Allowed'].strip()
             if trunk_vlans != 'none':
                 non_native_list = parse_vlans(trunk_vlans)
-            else:
-                non_natives = None
             if native_vlan is not None:
                 network_list.append(('vlan/native', native_vlan))
             for v in (non_native_list):

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -14,7 +14,6 @@ from hil.errors import BadArgumentError
 from os.path import join, dirname
 from hil.migrations import paths
 from hil.model import BigIntegerType
-<<<<<<< refs/remotes/upstream/master
 from hil.config import core_schema, string_is_bool
 from hil.ext.switches.common import parse_vlans
 
@@ -36,16 +35,16 @@ class Nexus(Switch):
         'polymorphic_identity': api_name,
     }
 
-    #id = db.Column(BigIntegerType,
-    #               db.ForeignKey('switch.id'), primary_key=True)
-    #hostname = db.Column(db.String, nullable=False)
-    #username = db.Column(db.String, nullable=False)
-    #password = db.Column(db.String, nullable=False)
-    #dummy_vlan = db.Column(db.String, nullable=False)
-    hostname = '192.168.3.230'
-    username = 'admin'
-    password = '.bluegit4'
-    dummy_vlan = 0
+    id = db.Column(BigIntegerType,
+                   db.ForeignKey('switch.id'), primary_key=True)
+    hostname = db.Column(db.String, nullable=False)
+    username = db.Column(db.String, nullable=False)
+    password = db.Column(db.String, nullable=False)
+    dummy_vlan = db.Column(db.String, nullable=False)
+    #hostname = '192.168.3.230'
+    #username = 'admin'
+    #password = '.bluegit4'
+    #dummy_vlan = 0
 
     @staticmethod
     def validate(kwargs):
@@ -254,10 +253,10 @@ class _Session(_console.Session):
 
 
 
-switcher = Nexus()
+#switcher = Nexus()
 # test port 19 too
-ports = [Port('Ethernet1/19', switcher), Port('Ethernet1/27', switcher), Port('Ethernet1/25', switcher)]
+#ports = [Port('Ethernet1/19', switcher), Port('Ethernet1/27', switcher), Port('Ethernet1/25', switcher)]
 #ports = [Port('Ethernet1/19', switcher)]
 #ports = [Port('gi1/0/3', switcher)]
-print switcher.session()._port_configs(ports)
-print switcher.session().get_port_networks(ports)
+#print switcher.session()._port_configs(ports)
+#print switcher.session().get_port_networks(ports)

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -41,10 +41,6 @@ class Nexus(Switch):
     username = db.Column(db.String, nullable=False)
     password = db.Column(db.String, nullable=False)
     dummy_vlan = db.Column(db.String, nullable=False)
-    #hostname = '192.168.3.230'
-    #username = 'admin'
-    #password = '.bluegit4'
-    #dummy_vlan = 0
 
     @staticmethod
     def validate(kwargs):
@@ -183,45 +179,6 @@ class _Session(_console.Session):
 
         return result
 
-    '''def get_port_networks(self, ports):
-        num_re = re.compile(r'(\d+)')
-        port_configs = self._port_configs(ports)
-        result = {}
-
-        for k, v in port_configs.iteritems():
-            networks = []
-            if 'Trunking Native Mode VLAN' not in v:
-                # XXX (probable BUG): For some reason the last port on the
-                # switch sometimes isn't read correctly. For now just don't use
-                # that port for the test suite, and will skip it if this
-                # happens.
-                continue
-            native = v['Trunking Native Mode VLAN'].strip()
-            match = re.match(num_re, native)
-            if match:
-                num_str = match.groups()[0]
-                native = int(num_str)
-                if native == int(self.switch.dummy_vlan):
-                    native = None
-            else:
-                native = None
-            for range_str in v['Trunking VLANs Allowed'].split(','):
-                # XXX TODO make this actualy interpret e.g. 2-7 as a *range*
-                for num_str in range_str.split('-'):
-                    num_str = num_str.strip()
-                    match = re.match(num_re, num_str)
-                    if match:
-                        # There may be other tokens in the output, e.g.
-                        # the string "(Inactive)" somteimtes appears.
-                        # We should only use the value if it's an actual
-                        # number.
-                        num_str = match.groups()[0]
-                        networks.append(('vlan/%s' % num_str, int(num_str)))
-
-            if native is not None:
-                networks.append(('vlan/native', native))
-            result[k] = networks
-        return result'''
 
     def get_port_networks(self, ports):
           port_configs = self._port_configs(ports)
@@ -289,13 +246,3 @@ class _Session(_console.Session):
     def disable_port(self):
         self._sendline('sw trunk allowed vlan none')
         self._sendline('sw trunk native vlan ' + self.dummy_vlan)
-
-
-
-#switcher = Nexus()
-# test port 19 too
-#ports = [Port('Ethernet1/19', switcher), Port('Ethernet1/27', switcher), Port('Ethernet1/25', switcher)]
-#ports = [Port('Ethernet1/19', switcher)]
-#ports = [Port('gi1/0/3', switcher)]
-#print switcher.session()._port_configs(ports)
-#print switcher.session().get_port_networks(ports)

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -181,36 +181,31 @@ class _Session(_console.Session):
 
 
     def get_port_networks(self, ports):
-          port_configs = self._port_configs(ports)
-          network_list = []
-          for k, v in port_configs.iteritems():
-              non_natives = ''
-              non_native_list = []
-              # Get native vlan then remove junk if native not None
-              native_vlan = v['Trunking Native Mode VLAN'].strip()
-              if native_vlan == int(self.switch.dummy_vlan):
-                  native_vlan = None
-              elif native_vlan != 'none':
-                  temp = ''
-                  for c in native_vlan:
-                      if c == ' ':
-                          break
-                      temp += c
-                  native_vlan = temp
-              else:
-                  native_vlan = None
-              # Get other vlans
-              trunk_vlans = v['Trunking VLANs Allowed'].strip()
-              if trunk_vlans != 'none':
-                  non_native_list = parse_vlans(trunk_vlans)
-              else:
-                  non_natives = None
-              if native_vlan is not None:
-                  network_list.append(('vlan/native', native_vlan))
-              for v in (non_native_list):
-                  if v != native_vlan:
-                      network_list.append(('vlan/%s' % v, int(v)))
-          return network_list
+        port_configs = self._port_configs(ports)
+        network_list = []
+        for k, v in port_configs.iteritems():
+            non_natives = ''
+            non_native_list = []
+            # Get native vlan then remove junk if native not None
+            native_vlan = v['Trunking Native Mode VLAN'].strip()
+            if native_vlan == int(self.switch.dummy_vlan):
+                native_vlan = None
+            elif native_vlan != 'none':
+                native_vlan = native_vlan.split(' ')[0]
+            else:
+                native_vlan = None
+            # Get other vlans
+            trunk_vlans = v['Trunking VLANs Allowed'].strip()
+            if trunk_vlans != 'none':
+                non_native_list = parse_vlans(trunk_vlans)
+            else:
+                non_natives = None
+            if native_vlan is not None:
+                network_list.append(('vlan/native', native_vlan))
+            for v in (non_native_list):
+                if v != native_vlan:
+                    network_list.append(('vlan/%s' % v, int(v)))
+        return network_list
 
     def save_running_config(self):
         self._sendline('copy running-config startup-config')

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -190,7 +190,7 @@ class _Session(_console.Session):
               native_vlan = v['Trunking Native Mode VLAN'].strip()
               if native_vlan == int(self.switch.dummy_vlan):
                   native_vlan = None
-              elif (native_vlan != 'none'):
+              elif native_vlan != 'none':
                   temp = ''
                   for c in native_vlan:
                       if c == ' ':
@@ -201,7 +201,7 @@ class _Session(_console.Session):
                   native_vlan = None
               # Get other vlans
               trunk_vlans = v['Trunking VLANs Allowed'].strip()
-              if (trunk_vlans != 'none'):
+              if trunk_vlans != 'none':
                   non_native_list = parse_vlans(trunk_vlans)
               else:
                   non_natives = None

--- a/hil/ext/switches/nexus.py
+++ b/hil/ext/switches/nexus.py
@@ -184,9 +184,16 @@ class _Session(_console.Session):
         VLANs.'''
         port_configs = self._port_configs(ports)
         result = {}
+
         for k, v in port_configs.iteritems():
             network_list = []
             non_native_list = []
+            if 'Trunking Native Mode VLAN' not in v:
+                # XXX (probable BUG): For some reason the last port on the
+                # switch sometimes isn't read correctly. For now just don't use
+                # that port for the test suite, and will skip it if this
+                # happens.
+                continue
             # Get native vlan then remove junk if native is not None or Dummy
             native_vlan = v['Trunking Native Mode VLAN'].strip()
             if int(native_vlan.split(' ')[0]) == int(self.switch.dummy_vlan):
@@ -200,6 +207,8 @@ class _Session(_console.Session):
             if trunk_vlans != 'none':
                 non_native_list = parse_vlans(trunk_vlans)
             if native_vlan is not None:
+                # Ensure that native vlan is not in the non-native list
+                non_native_list.remove(native_vlan)
                 network_list.append(('vlan/native', int(native_vlan)))
             for v in (non_native_list):
                 network_list.append(('vlan/%s' % v, int(v)))

--- a/tests/deployment/multi_networks.py
+++ b/tests/deployment/multi_networks.py
@@ -1,0 +1,154 @@
+"""Test various properties re: vlan tagged networks, on real hardware.
+
+For guidance on running these tests, see the section on deployment
+tests in docs/testing.md
+"""
+
+import json
+
+from hil import api, model, deferred, config
+from hil.test_common import config_testsuite, fail_on_log_warnings, \
+    fresh_database, with_request_context, site_layout, NetworkTest, \
+    network_create_simple, server_init
+import pytest
+
+
+@pytest.fixture
+def configure():
+    """Configure HIL."""
+    config_testsuite()
+    config.load_extensions()
+
+
+fail_on_log_warnings = pytest.fixture(autouse=True)(fail_on_log_warnings)
+fresh_database = pytest.fixture(fresh_database)
+server_init = pytest.fixture(server_init)
+
+
+with_request_context = pytest.yield_fixture(with_request_context)
+
+site_layout = pytest.fixture(site_layout)
+
+pytestmark = pytest.mark.usefixtures('configure',
+                                     'server_init',
+                                     'fresh_database',
+                                     'with_request_context',
+                                     'site_layout')
+
+
+class TestMultiNets(NetworkTest):
+    """NetworkTest using multiple tagged vlan networks on a port."""
+
+    def test_multi_networks(self):
+        """Do a bunch of network operations on the switch, and verify things
+        along the way.
+
+        The above is super vague; unfortunately the setup operations are very
+        slow, so it makes a huge difference to do everything in one pass. See
+        the comments in-line to understand exactly what is being tested.
+        """
+
+        def get_legal_channels(network):
+            """Get the legal channels for a network."""
+            response_body = api.show_network(network)
+            response_body = json.loads(response_body)
+            return response_body['channels']
+
+        def create_multi_nets():
+            """Create multiple networks and connect them all to one port.
+
+            Test that each network can be successfully added and discovered
+            on the port.
+            """
+
+            nodes = self.collect_nodes()
+
+            deferred.apply_networking()
+
+            # create 5 networks
+            network_create_simple('net-0', 'anvil-nextgen')
+            network_create_simple('net-1', 'anvil-nextgen')
+            network_create_simple('net-2', 'anvil-nextgen')
+            network_create_simple('net-3', 'anvil-nextgen')
+            network_create_simple('net-4', 'anvil-nextgen')
+
+            ports = self.get_all_ports(nodes)
+
+            # assert that node 0 is not on any network
+            port_networks = self.get_port_networks(ports)
+            assert self.get_network(nodes[0].nics[0].port, port_networks) == \
+                set()
+
+            # get channel IDs for tagged versions of networks
+            net_tag = {}
+            net_tag[0] = get_legal_channels('net-0')[1]
+            net_tag[1] = get_legal_channels('net-1')[1]
+            net_tag[2] = get_legal_channels('net-2')[1]
+            net_tag[3] = get_legal_channels('net-3')[1]
+
+            # connect node 0 to net-0 in native mode
+            api.node_connect_network(nodes[0].label,
+                                     nodes[0].nics[0].label,
+                                     'net-0')
+            deferred.apply_networking()
+            # connect node 0 to net-1 in tagged mode
+            api.node_connect_network(nodes[0].label,
+                                     nodes[0].nics[0].label,
+                                     'net-1',
+                                     channel=net_tag[1])
+            deferred.apply_networking()
+            # connect node 0 to net-2 in tagged mode
+            api.node_connect_network(nodes[0].label,
+                                     nodes[0].nics[0].label,
+                                     'net-2',
+                                     channel=net_tag[2])
+            deferred.apply_networking()
+            # connect node 0 to net-3 in tagged mode
+            api.node_connect_network(nodes[0].label,
+                                     nodes[0].nics[0].label,
+                                     'net-3',
+                                     channel=net_tag[3])
+            deferred.apply_networking()
+
+            # assert that all networks show up on the port
+            port_networks = self.get_port_networks(ports)
+            networks = \
+                set([net for net,
+                    _channel in port_networks.get(nodes[0].nics[0].port)])
+            # create a list of networks with native net-0 included
+            networks_added = set([get_legal_channels('net-0')[0],
+                                 net_tag[0], net_tag[1],
+                                 net_tag[2], net_tag[3]])
+            assert networks == networks_added
+
+        def teardown():
+            """Teardown the setup from create_multi_nets.
+            """
+            # Query the DB for nodes on this project
+            project = api.get_or_404(model.Project, 'anvil-nextgen')
+            nodes = project.nodes
+            ports = self.get_all_ports(nodes)
+
+            # Remove all nodes from their networks using port_revert.
+            for node in nodes:
+                port = node.nics[0].port
+                api.port_revert(port.owner.label, port.label)
+            deferred.apply_networking()
+
+            # Assert that none of the nodes are on any network
+            port_networks = self.get_port_networks(ports)
+            for node in nodes:
+                assert self.get_network(node.nics[0].port, port_networks) == \
+                    set()
+
+            # Delete the networks
+            api.network_delete('net-0')
+            api.network_delete('net-1')
+            api.network_delete('net-2')
+            api.network_delete('net-3')
+
+        # Create a project
+        api.project_create('anvil-nextgen')
+
+        create_multi_nets()
+        teardown()

--- a/tests/deployment/multi_networks.py
+++ b/tests/deployment/multi_networks.py
@@ -63,8 +63,6 @@ class TestMultiNets(NetworkTest):
 
             nodes = self.collect_nodes()
 
-            deferred.apply_networking()
-
             # create 5 networks
             network_create_simple('net-0', 'anvil-nextgen')
             network_create_simple('net-1', 'anvil-nextgen')
@@ -117,7 +115,7 @@ class TestMultiNets(NetworkTest):
                     _channel in port_networks.get(nodes[0].nics[0].port)])
             # create a list of networks with native net-0 included
             networks_added = set([get_legal_channels('net-0')[0],
-                                 net_tag[0], net_tag[1],
+                                 net_tag[1],
                                  net_tag[2], net_tag[3]])
             assert networks == networks_added
 

--- a/tests/deployment/multi_networks.py
+++ b/tests/deployment/multi_networks.py
@@ -40,12 +40,13 @@ class TestMultiNets(NetworkTest):
     """NetworkTest using multiple tagged vlan networks on a port."""
 
     def test_multi_networks(self):
-        """Do a bunch of network operations on the switch, and verify things
-        along the way.
-
-        The above is super vague; unfortunately the setup operations are very
-        slow, so it makes a huge difference to do everything in one pass. See
-        the comments in-line to understand exactly what is being tested.
+        """A suite of tests to ensure that multiple networks can relate
+        to a single port. Previously, there was an issue with
+        get_port_networks() where it didn't return the full range of
+        vlans, rather it returned only the ones at the ends of the ranges.
+        These tests ensure that the full range of vlans can be fetched.
+        Issue: https://github.com/CCI-MOC/hil/issues/921
+        See the inline comments for the specifics.
         """
 
         def get_legal_channels(network):
@@ -64,11 +65,8 @@ class TestMultiNets(NetworkTest):
             nodes = self.collect_nodes()
 
             # create 5 networks
-            network_create_simple('net-0', 'anvil-nextgen')
-            network_create_simple('net-1', 'anvil-nextgen')
-            network_create_simple('net-2', 'anvil-nextgen')
-            network_create_simple('net-3', 'anvil-nextgen')
-            network_create_simple('net-4', 'anvil-nextgen')
+            for i in range(5):
+                network_create_simple('net-%d' % i, 'anvil-nextgen')
 
             ports = self.get_all_ports(nodes)
 
@@ -79,10 +77,8 @@ class TestMultiNets(NetworkTest):
 
             # get channel IDs for tagged versions of networks
             net_tag = {}
-            net_tag[0] = get_legal_channels('net-0')[1]
-            net_tag[1] = get_legal_channels('net-1')[1]
-            net_tag[2] = get_legal_channels('net-2')[1]
-            net_tag[3] = get_legal_channels('net-3')[1]
+            for i in range(4):
+                net_tag[i] = get_legal_channels('net-%d' % i)[1]
 
             # connect node 0 to net-0 in native mode
             api.node_connect_network(nodes[0].label,


### PR DESCRIPTION
- Addresses #921
- Effects PowerConnect, Nexus, and N3000 switches.
- `get_port_networks()` now returns every VLAN in the ranges rather than the ones at the end of the ranges.
- I am releasing this now for review to get feedback before writing the deployment tests to test more than two trunking VLANs