### PR TITLE
Remove pointless test.

### DIFF
--- a/tests/unit/client.py
+++ b/tests/unit/client.py
@@ -273,15 +273,6 @@ pytestmark = pytest.mark.usefixtures('dummy_verify',
 class Test_ClientBase:
     """Tests client initialization and object_url creation. """
 
-    def test_init_error(self):
-        """Test that we get a TypeError given bad arguments to ClientBase()"""
-        # XXX: I(zenhack) think this test is of dubious utility; At some point
-        # during review, Sahil had some explicit logic to throw this error, but
-        # we got rid of that. Arguably we should remove this, but I want to do
-        # so in a separate patch, so just noting it now.
-        with pytest.raises(TypeError):
-            ClientBase()
-
     def test_object_url(self):
         """Test the object_url method."""
         x = ClientBase(ep, 'some_base64_string')


### PR DESCRIPTION
See the (now removed) comment; IIRC at one point or another ClientBase
had an explicit `raise TypeError`, which got replaced with just fixing
the function signature, but this test got left behind.