### PR TITLE
Optimize postgres to make it run slightly faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
 install:
   # A dependency might use new pip syntax; upgrade to prevent breakage. See #771
   - pip install --upgrade pip
+  - sh -e ci/optimize_postgres.sh
   - sh -e ci/hil_install.sh
   - sh -e ci/apache/install.sh
   - sh -e ci/keystone/install.sh

--- a/ci/optimize_postgres.sh
+++ b/ci/optimize_postgres.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -ex
+
+# Skip if we are in the sqlite build
+if [ $DB = sqlite ]; then
+    exit 0
+fi
+
+# these changes optimize postgres. They are fine for testing, but not suitable
+# for production.
+# See https://www.postgresql.org/docs/current/static/non-durability.html
+echo "fsync = off
+synchronous_commit = off
+full_page_writes = off
+checkpoint_timeout = 30min
+"| sudo tee --append /etc/postgresql/9.*/main/postgresql.conf
+
+sudo service postgresql restart


### PR DESCRIPTION
This patch modifies the postgres configuration file and then restarts the
postgres server.

Locally this made a significant difference, but in Travis it only seems to save a minute or so. I don't know if it's worth it, but we can discuss if we want this or not.

Anybody want to test this locally too (so that we can be sure that there isn't something else going on in my local environment).