### PR TITLE
Install obmd only when running integration tests

### DIFF
--- a/ci/obmd/install.sh
+++ b/ci/obmd/install.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 set -ex
 
+# Exit if we are only running unit tests
+if [ $TEST_SUITE = unit ]; then
+    exit 0
+fi
+
 # The version of Go available in trusty by default is too old; install
 # a newer one from PPA. See also:
 #


### PR DESCRIPTION
* doing apt-get update and then dowloading go-lang (~100MB) takes up a minute
or so.

Edit:
Actually, it takes way more than a minute. From the build of this PR:
"Fetched 108 MB in 5min 26s (330 kB/s)"