### PR TITLE
use postgres 9.6 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
   - pip
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
   apt:
     packages:
       - apache2


### PR DESCRIPTION
There are some under the hood performance improvements that we might benefit from in our CI. 
https://www.postgresql.org/about/featurematrix/#performance

Travis images don't have postgres 10, though we can manually install it but it's way too much work for no benefit imo, I did it here https://github.com/CCI-MOC/hil/compare/master...naved001:use-postgres-10
All the manual setup causes it to be slower than the already available postgres 9.X. You can see the travis builds for that here https://travis-ci.org/naved001/hil/builds/386740666