### PR TITLE
WIP: Prototype driver to talk to Dellos9 switches using ansible networking modules.

### DIFF
--- a/hil/ext/switches/ansible/dellos9.py
+++ b/hil/ext/switches/ansible/dellos9.py
@@ -1,0 +1,153 @@
+"""This module holds the functions that make appropriate dictionary objects
+and run those using ansible_runner.
+
+Currently this is hardcoded to work with dellos9_{config, command}
+"""
+import ansible_runner
+
+
+def host_information(host, user, password, ansible_network_os):
+    """Generates the dictionary object with host information.
+
+    Will simplify this later"""
+    return {
+        'hosts': {
+            'myswitch': {
+                'ansible_host': host,
+            }
+        },
+        'vars': {
+            'ansible_user': user,
+            'ansible_password': password
+        },
+        'children': {
+            'switch': {
+                'vars': {
+                    'ansible_network_os': ansible_network_os,
+                },
+                'hosts': {
+                    'myswitch': {}
+                }
+            }
+        }
+    }
+
+
+def run_config_command(command, name):
+    """Run any config command <command>
+
+    Command must be a list.
+    Name is the name of the command
+    """
+    config_command = {
+        "name": name,
+        "dellos9_config": {
+            "commands": command
+        }
+    }
+    return [config_command]
+
+
+def run_show_command(command, name):
+    """Run a show command <command> and give it <name>
+
+    It stores the output in stdout so that we can parse it because at this
+    point I don't know how to store outputs in python variables using ansible
+    runner"""
+    gather_information = {
+        "name": name,
+        "dellos9_command": {
+            "commands": command
+        },
+        "register": "output"
+    }
+    print_to_stdout = {
+        "name": "output to stdout",
+        "debug": {
+            "var": "output.stdout_lines",
+        }
+    }
+    tasks = [gather_information, print_to_stdout]
+    return tasks
+
+
+def port_off(port):
+    """Power off port"""
+    goto_switchport = ['interface gigabitethernet ' + port]
+    disable_switchport = ['no switchport', 'no portmode hybrid', 'shutdown']
+    commands = goto_switchport + disable_switchport
+    return run_config_command(commands, "port off")
+
+
+def port_on(port):
+    """Power on port"""
+    goto_switchport = ['interface gigabitethernet ' + port]
+    enable_switchport = ['portmode hybrid', 'switchport', 'no shutdown']
+    commands = goto_switchport + enable_switchport
+    return run_config_command(commands, "port on")
+
+
+def add_trunk_vlan(port, trunk_vlan):
+    """Sets the VLANs using the dellos9_config module"""
+    goto_switchport = ['interface gigabitethernet ' + port]
+    enable_switchport = ['portmode hybrid', 'switchport', 'no shutdown']
+    add_vlan = ['interface vlan ' + trunk_vlan,
+                'tagged gigabitethernet ' + port]
+    commands = goto_switchport + enable_switchport + add_vlan
+    return run_config_command(commands, "add vlan to trunk")
+
+
+def add_native_vlan(port, native_vlan):
+    """Sets the VLANs using the dellos9_config module"""
+    goto_switchport = ['interface gigabitethernet ' + port]
+    enable_switchport = ['portmode hybrid', 'switchport', 'no shutdown']
+    add_vlan = ['interface vlan ' + native_vlan,
+                'untagged gigabitethernet ' + port]
+    commands = goto_switchport + enable_switchport + add_vlan
+    return run_config_command(commands, "add native vlan")
+
+
+def remove_native_vlan(port, native_vlan):
+    """Remove the native vlan and power it off.
+
+    Ideally, I should power off the port separately, but this
+    is more efficient to do in one call"""
+    remove_native = ['interface vlan ' + native_vlan,
+                     'no untagged gigabitethernet ' + port]
+    goto_switchport = ['interface gigabitethernet ' + port]
+    disable_switchport = ['no switchport', 'no portmode hybrid', 'shutdown']
+    commands = remove_native + goto_switchport + disable_switchport
+
+    return run_config_command(commands, "remove native vlan")
+
+
+def get_port_info(port):
+    """Create the dictionary object to gather port information"""
+    command = ["show interface switchport gigabitethernet " + port]
+    return run_show_command(command, "show port information")
+
+
+def run_task(tasks, hosts):
+    """Run <tasks> on <hosts>
+
+    tasks is a list.
+    hosts is a dictionary containing hosts.
+    return stdout
+    """
+    playbook = {
+        "hosts": "switch",
+        "gather_facts": False,
+        "connection": "local",
+        "tasks": tasks
+    }
+
+    kwargs = {
+        'playbook': [playbook],
+        'inventory': {'all': hosts},
+    }
+
+    result = ansible_runner.run(**kwargs)
+
+    stdout = result.stdout.read()
+
+    return stdout

--- a/hil/ext/switches/ansible/dellos9.py
+++ b/hil/ext/switches/ansible/dellos9.py
@@ -90,10 +90,9 @@ def port_on(port):
 def add_trunk_vlan(port, trunk_vlan):
     """Sets the VLANs using the dellos9_config module"""
     goto_switchport = ['interface gigabitethernet ' + port]
-    enable_switchport = ['portmode hybrid', 'switchport', 'no shutdown']
     add_vlan = ['interface vlan ' + trunk_vlan,
                 'tagged gigabitethernet ' + port]
-    commands = goto_switchport + enable_switchport + add_vlan
+    commands = goto_switchport + add_vlan
     return run_config_command(commands, "add vlan to trunk")
 
 
@@ -145,7 +144,6 @@ def run_task(tasks, hosts):
         'playbook': [playbook],
         'inventory': {'all': hosts},
     }
-
     result = ansible_runner.run(**kwargs)
 
     stdout = result.stdout.read()

--- a/hil/ext/switches/dellnos9ansible.py
+++ b/hil/ext/switches/dellnos9ansible.py
@@ -184,7 +184,7 @@ class DellNOS9Ansible(Switch, _vlan_http.Session):
             vlan: vlan to remove
         """
         command = self._remove_vlan_command(port, vlan)
-        task = ansible_dellos9.run_config_command(command)
+        task = ansible_dellos9.run_config_command(command, "remove trunk vlan")
         ansible_dellos9.run_task(task, self.host_information)
 
     # def _remove_all_vlans_from_trunk(self, port):

--- a/hil/ext/switches/dellnos9ansible.py
+++ b/hil/ext/switches/dellnos9ansible.py
@@ -1,0 +1,268 @@
+"""A switch driver for Dell S3048-ON running Dell OS 9.
+
+Uses Ansible networking to manage the switch
+"""
+
+import logging
+import re
+from schema import Schema, Optional
+
+from hil.model import db, Switch
+from hil.errors import BadArgumentError
+from hil.model import BigIntegerType
+from hil.ext.switches.common import check_native_networks, parse_vlans
+from hil.config import core_schema, string_is_bool
+from hil.ext.switches import _vlan_http
+
+import hil.ext.switches.ansible.dellos9 as ansible_dellos9
+
+
+logger = logging.getLogger(__name__)
+
+core_schema[__name__] = {
+    Optional('save'): string_is_bool
+}
+
+
+class DellNOS9Ansible(Switch, _vlan_http.Session):
+    """Dell S3048-ON running Dell NOS9"""
+    api_name = 'http://schema.massopencloud.org/haas/v0/switches/dellnos9ansible'
+
+    __mapper_args__ = {
+        'polymorphic_identity': api_name,
+    }
+
+    id = db.Column(BigIntegerType,
+                   db.ForeignKey('switch.id'), primary_key=True)
+    hostname = db.Column(db.String, nullable=False)
+    username = db.Column(db.String, nullable=False)
+    password = db.Column(db.String, nullable=False)
+    port_type = db.Column(db.String, nullable=False)
+
+    @property
+    def host_information(self):
+        """Return the dictionary containing host information needed by ansible
+        runner.
+        """
+        # This is the dictionary object; could probably trim this down a little.
+        return {
+            'hosts': {
+                'myswitch': {
+                    'ansible_host': self.hostname,
+                }
+            },
+            'vars': {
+                'ansible_user': self.username,
+                'ansible_password': self.password
+            },
+            'children': {
+                'switch': {
+                    'vars': {
+                        'ansible_network_os': "dellos9",
+                    },
+                    'hosts': {
+                        'myswitch': {}
+                    }
+                }
+            }
+        }
+
+    @staticmethod
+    def validate(kwargs):
+        Schema({
+            'hostname': basestring,
+            'username': basestring,
+            'password': basestring,
+            'port_type': basestring,
+        }).validate(kwargs)
+
+    def session(self):
+        return self
+
+    def ensure_legal_operation(self, nic, op_type, channel):
+        check_native_networks(nic, op_type, channel)
+
+    def get_capabilities(self):
+        return []
+
+    @staticmethod
+    def validate_port_name(port):
+        """Valid port names for this switch are of the form 1/0/1 or 1/2"""
+
+        if not re.match(r'^\d+/\d+(/\d+)?$', port):
+            raise BadArgumentError("Invalid port name. Valid port names for "
+                                   "this switch are of the form 1/0/1 or 1/2")
+
+    def _is_port_on(self, port):
+        """ Returns a boolean that tells the status of a switchport"""
+        command = ["show running-config interface gigabitethernet " + port]
+        task = ansible_dellos9.run_show_command(command, "check if port is on")
+        response = ansible_dellos9.run_task(task, self.host_information)
+        match = re.search(r'no shutdown', response)
+        if match is not None:
+            return True
+        else:
+            match = re.search(r'shutdown', response)
+            if match is None:
+                assert False, "unexpected state of switchport"
+            else:
+                return False
+
+    def _get_vlans(self, port):
+        """ Return the vlans of a trunk port.
+
+        Does not include the native vlan. Use _get_native_vlan.
+
+        Args:
+            port: port to return the vlans of
+
+        Returns: List containing the vlans of the form:
+        [('vlan/vlan1', vlan1), ('vlan/vlan2', vlan2)]
+        """
+        if not self._is_port_on(port):
+            return []
+        response = self._get_port_info(port)
+        response = response.replace(' ', '')
+
+        # finds a comma separated list of integers and/or ranges starting with
+        # T. Sample T12,14-18,23,28,80-90 or T20 or T20,22 or T20-22
+        match = re.search(r'T(\d+(-\d+)?)(,\d+(-\d+)?)*', response)
+        if match is None:
+            return []
+
+        vlan_list = parse_vlans(match.group().replace('T', ''))
+
+        return [('vlan/%s' % x, x) for x in vlan_list]
+
+    def _get_native_vlan(self, port):
+        """ Return the native vlan of an port.
+
+        Args:
+            port: port to return the native vlan of
+
+        Returns: Tuple of the form ('vlan/native', vlan) or None
+
+        Similar to _get_vlans()
+        """
+        if not self._is_port_on(port):
+            return None
+        response = self._get_port_info(port)
+        response = response.replace(' ', '')
+        match = re.search(r'NativeVlanId:(\d+)\.', response)
+        if match is not None:
+            vlan = match.group(1)
+        else:
+            logger.error('Unexpected: No native vlan found')
+            return
+
+        return ('vlan/native', vlan)
+
+    def _get_port_info(self, port):
+        """Returns port information"""
+        task = ansible_dellos9.get_port_info(port)
+        response = ansible_dellos9.run_task(task, self.host_information)
+        return response
+
+    def _add_vlan_to_trunk(self, port, vlan):
+        """ Add a vlan to a trunk port.
+
+        The HIL API makes sure that this can only be called after a native
+        vlan is already set which turns on the port and enables switching.
+
+        Args:
+            port: port to add the vlan to
+            vlan: vlan to add
+        """
+        task = ansible_dellos9.add_trunk_vlan(port, vlan)
+        ansible_dellos9.run_task(task, self.host_information)
+
+    def _remove_vlan_from_trunk(self, port, vlan):
+        """ Remove a vlan from a trunk port.
+
+        Args:
+            port: port to remove the vlan from
+            vlan: vlan to remove
+        """
+        command = self._remove_vlan_command(port, vlan)
+        task = ansible_dellos9.run_show_command(command)
+        ansible_dellos9.run_task(task, self.host_information)
+
+    # def _remove_all_vlans_from_trunk(self, port):
+    #     """ Remove all vlan from a trunk port.
+
+    #     Args:
+    #         port: port to remove the vlan from
+    #     """
+    #     # I COULDNT GET THIS TO WORK. IT ONLY REMOVES THE FIRST VLAN IN THE
+    #     # LIST
+
+    #     # generate a big command to remove all vlans in one trip
+    #     command = []
+    #     for vlan in self._get_vlans(port):
+    #         command += self._remove_vlan_command(port, vlan[1])
+    #     # execute command only if there are some vlans to remove, otherwise
+    #     # the switch complains
+    #     if command is not []:
+    #         task = ansible_dellos9.run_config_command(
+    #             command, "remove all trunk vlans")
+    #         ansible_dellos9.run_task(task, self.host_information)
+
+    def _remove_all_vlans_from_trunk(self, port):
+        """ Remove all vlan from a trunk port.
+
+        Args:
+            port: port to remove the vlan from
+        """
+        for vlan in self._get_vlans(port):
+            command = self._remove_vlan_command(port, vlan[1])
+            task = ansible_dellos9.run_config_command(
+                command, "remove vlan: " + vlan[1])
+            ansible_dellos9.run_task(task, self.host_information)
+
+    def _remove_vlan_command(self, port, vlan):
+        """Returns command to remove <vlan> from <port>"""
+        return ['interface vlan ' + vlan, 'no tagged ' + self.port_type + ' ' + port]
+
+    def _set_native_vlan(self, port, vlan):
+        """ Set the native vlan of an port.
+
+        Args:
+            port: port to set the native vlan to
+            vlan: vlan to set as the native vlan
+
+        Method relies on the REST API CLI which is slow
+        """
+        if not self._is_port_on(port):
+            self._port_on(port)
+        task = ansible_dellos9.add_native_vlan(port, vlan)
+        ansible_dellos9.run_task(task, self.host_information)
+
+    def _remove_native_vlan(self, port):
+        """ Remove the native vlan from a port.
+
+        Args:
+            port: port to remove the native vlan from.vlan
+        """
+        try:
+            vlan = self._get_native_vlan(port)[1]
+            task = ansible_dellos9.remove_native_vlan(port, vlan)
+            ansible_dellos9.run_task(task, self.host_information)
+        except TypeError:
+            logger.error('No native vlan to remove')
+
+    def _port_shutdown(self, port):
+        """ Shuts down <port>
+
+        Turn off portmode hybrid, disable switchport, and then shut down the
+        port. All non-default vlans must be removed before calling this.
+        """
+        task = ansible_dellos9.port_off(port)
+        ansible_dellos9.run_task(task, self.host_information)
+
+    def _port_on(self, port):
+        """ Turns on <port>
+
+        Turn on port and enable hybrid portmode and switchport.
+        """
+        task = ansible_dellos9.port_on(port)
+        ansible_dellos9.run_task(task, self.host_information)

--- a/hil/ext/switches/dellnos9ansible.py
+++ b/hil/ext/switches/dellnos9ansible.py
@@ -95,7 +95,7 @@ class DellNOS9Ansible(Switch, _vlan_http.Session):
 
     def _is_port_on(self, port):
         """ Returns a boolean that tells the status of a switchport"""
-        command = ["show running-config interface gigabitethernet " + port]
+        command = "show running-config interface gigabitethernet " + port
         task = ansible_dellos9.run_show_command(command, "check if port is on")
         response = ansible_dellos9.run_task(task, self.host_information)
         match = re.search(r'no shutdown', response)
@@ -184,7 +184,7 @@ class DellNOS9Ansible(Switch, _vlan_http.Session):
             vlan: vlan to remove
         """
         command = self._remove_vlan_command(port, vlan)
-        task = ansible_dellos9.run_show_command(command)
+        task = ansible_dellos9.run_config_command(command)
         ansible_dellos9.run_task(task, self.host_information)
 
     # def _remove_all_vlans_from_trunk(self, port):


### PR DESCRIPTION
Still a work in progress, I am opening this to start some discussion and gather some feedback.

Few things:

1. The test switch I am using is a Dell S3048-ON running Dell OS9.
2. I am using the [dellos9_config](http://docs.ansible.com/ansible/latest/modules/dellos9_config_module.html#dellos9-config-module) module to set the vlans and turn on switchport. And the [dellos9_commands](http://docs.ansible.com/ansible/latest/modules/dellos9_command_module.html#dellos9-command-module) to gather port information (is port on or not, trunk and native vlan information).
3. There's this [dellos vlan role](https://github.com/Dell-Networking/ansible-role-dellos-vlan) which can set vlans on dellos6,9 and 10. I might try that in the future but is there a role equivalent to dellosX_commands? That way the driver can be truly generic, at least for the dell switches. The dellos9_config module only acts a transport for my commands. I still have to write the commands in a way the particular switch can digest.
4. I have a cisco switch which supports the nicer [nx-os modules](http://docs.ansible.com/ansible/latest/modules/list_of_network_modules.html#nxos), I'll try and see how that plays. 

I can run the methods from the interpreter, but when I run our test suite, I get some errors from ansible_runner. Haven't really looked into it yet. 

cc: @zenhack @privateip 