### PR TITLE
Put an upper bound on pytest dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(name='hil',
                         ],
       extras_require={
           'tests': [
-                'pytest>=3.3.0,<3.6',
+                'pytest>=3.4.0,<3.6',
                 'pytest-cov>2.0,<3.0',
                 'pytest-xdist>=1.14,<2.0',
                 'pycodestyle>=2.3.1',

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(name='hil',
                         ],
       extras_require={
           'tests': [
-                'pytest>=3.3.0,<4.0',
+                'pytest>=3.3.0,<3.6',
                 'pytest-cov>2.0,<3.0',
                 'pytest-xdist>=1.14,<2.0',
                 'pycodestyle>=2.3.1',


### PR DESCRIPTION
I hit this while digging back in to the OBMd stuff. I suspect it's some problem with namespacing.