### PR TITLE
Add get power status

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -638,7 +638,7 @@ Possible Errors:
 
 #### node_power_status
 
-`POST /node/<node>/power_status`
+`GET /node/<node>/power_status`
 
 Returns the node's power status.
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -636,6 +636,28 @@ Possible Errors:
 
 * 409, if the node's OBM is not enabled (see node_enable_obm).
 
+#### node_power_status
+
+`POST /node/<node>/power_status`
+
+Returns the node's power status.
+
+Response body:
+
+    [
+        "power_status": "<IPMI chassis power status response>"
+    ]
+
+Response examples: "on" or "off" for IPMI, or "Mock Status" for mock OBM.
+
+Authorization requirements:
+
+* Access to the project to which `<node>` is assigned (if any) or administrative access.
+
+Possible Errors:
+
+* 409, if the node's OBM is not enabled (see node_enable_obm).
+
 #### show_console
 
 `GET /node/<node>/<console`

--- a/hil/api.py
+++ b/hil/api.py
@@ -302,6 +302,14 @@ def node_set_bootdev(node, bootdev):
     return _obmd_redirect(node, '/boot_device')
 
 
+@rest_call('GET', '/node/<node>/power_status', Schema({'node': basestring}))
+def node_power_status(node):
+    """Returns nodes power status"""
+    node = get_or_404(model.Node, node)
+    get_auth_backend().require_project_access(node.project)
+    return _obmd_redirect(node, '/power_status')
+
+
 @rest_call('DELETE', '/node/<node>', Schema({'node': basestring}))
 def node_delete(node):
     """Delete node.

--- a/hil/cli/node.py
+++ b/hil/cli/node.py
@@ -157,6 +157,13 @@ def node_power_cycle(node):
     client.node.power_cycle(node)
 
 
+@node_power.command(name='status')
+@click.argument('node')
+def node_power_status(node):
+    """Power cycle <node>"""
+    print client.node.power_status(node)
+
+
 @node.group(name='metadata')
 def node_metadata():
     """Node metadata commands"""

--- a/hil/cli/node.py
+++ b/hil/cli/node.py
@@ -160,7 +160,7 @@ def node_power_cycle(node):
 @node_power.command(name='status')
 @click.argument('node')
 def node_power_status(node):
-    """Power cycle <node>"""
+    """Returns node power status"""
     print client.node.power_status(node)
 
 

--- a/hil/cli/node.py
+++ b/hil/cli/node.py
@@ -161,7 +161,7 @@ def node_power_cycle(node):
 @click.argument('node')
 def node_power_status(node):
     """Returns node power status"""
-    print client.node.power_status(node)
+    print(client.node.power_status(node))
 
 
 @node.group(name='metadata')

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -83,7 +83,7 @@ class Node(ClientBase):
 
     @check_reserved_chars()
     def power_status(self, node_name):
-        """Power ons the <node> """
+        """Returns the power status of node """
         url = self.object_url('node', node_name, 'power_status')
         return self.check_response(self.httpClient.request('GET', url))
 

--- a/hil/client/node.py
+++ b/hil/client/node.py
@@ -82,6 +82,12 @@ class Node(ClientBase):
         return self.check_response(self.httpClient.request('POST', url))
 
     @check_reserved_chars()
+    def power_status(self, node_name):
+        """Power ons the <node> """
+        url = self.object_url('node', node_name, 'power_status')
+        return self.check_response(self.httpClient.request('GET', url))
+
+    @check_reserved_chars()
     def set_bootdev(self, node, dev):
         """Set <node> to boot from <dev> persistently"""
         url = self.object_url('node', node, 'boot_device')

--- a/hil/server.py
+++ b/hil/server.py
@@ -47,8 +47,7 @@ def stop_orphan_consoles():
     # Stop all orphan console logging processes on startup
     nodes = model.Node.query.all()
     for node in nodes:
-        node.obm.stop_console()
-        node.obm.delete_console()
+        node.disable_obm()
 
 
 def init():

--- a/tests/integration/client_integration.py
+++ b/tests/integration/client_integration.py
@@ -277,7 +277,7 @@ class Test_node:
         assert C.node.set_bootdev(obmd_node, "A") is None
 
     def test_power_status(self, obmd_node):
-        """(successful) to node_power_on"""
+        """(successful) to node_power_status"""
         C.node.enable_obm(obmd_node)
         resp = C.node.power_status(obmd_node)
         assert resp["power_status"] == "Mock Status"

--- a/tests/integration/client_integration.py
+++ b/tests/integration/client_integration.py
@@ -276,6 +276,12 @@ class Test_node:
         C.node.enable_obm(obmd_node)
         assert C.node.set_bootdev(obmd_node, "A") is None
 
+    def test_power_status(self, obmd_node):
+        """(successful) to node_power_on"""
+        C.node.enable_obm(obmd_node)
+        resp = C.node.power_status(obmd_node)
+        assert resp["power_status"] == "Mock Status"
+
     def test_node_add_nic(self):
         """Test removing and then adding a nic."""
         C.node.remove_nic('free_node_1', 'boot-nic')

--- a/tests/integration/obmd.py
+++ b/tests/integration/obmd.py
@@ -101,7 +101,7 @@ def _follow_redirect(method, resp, data=None, stream=False):
 def test_power_operations(mock_node):
     """Test the power-related obm api calls.
 
-    i.e. power_off, power_cycle, set_bootdev.
+    i.e. power_off, power_cycle, set_bootdev, power_status
     """
     # Obm is disabled; these should all fail:
     with pytest.raises(errors.BlockedError):
@@ -114,6 +114,8 @@ def test_power_operations(mock_node):
         api.node_power_cycle(mock_node, force=True)
     with pytest.raises(errors.BlockedError):
         api.node_power_cycle(mock_node, force=False)
+    with pytest.raises(errors.BlockedError):
+        api.node_power_status(mock_node)
     with pytest.raises(errors.BlockedError):
         api.show_console(mock_node)
 
@@ -129,7 +131,12 @@ def test_power_operations(mock_node):
             }))
 
     _follow_redirect('POST', api.node_power_off(mock_node))
+
+    resp = _follow_redirect('GET', api.node_power_status(mock_node))
+    assert json.loads(resp) == {'power_status': 'Mock Status'}
+
     _follow_redirect('POST', api.node_power_on(mock_node))
+
     _follow_redirect(
         'PUT',
         api.node_set_bootdev(mock_node, 'A'),

--- a/tests/integration/obmd.py
+++ b/tests/integration/obmd.py
@@ -133,7 +133,7 @@ def test_power_operations(mock_node):
     _follow_redirect('POST', api.node_power_off(mock_node))
 
     resp = _follow_redirect('GET', api.node_power_status(mock_node))
-    assert json.loads(resp) == {'power_status': 'Mock Status'}
+    assert json.loads(resp.content) == {'power_status': 'Mock Status'}
 
     _follow_redirect('POST', api.node_power_on(mock_node))
 


### PR DESCRIPTION
I was looking at stuff that needs to be in the 0.4 release, and noticed that get power_status wasn't in the code. It was pretty straightforward to do, so I just did it. Fixes #724 

Also update the stop_orphan_console method in hil/server.py