### PR TITLE
Nic delete

### DIFF
--- a/hil/api.py
+++ b/hil/api.py
@@ -360,10 +360,13 @@ def node_delete_nic(node, nic):
     """
 
     get_auth_backend().require_admin()
-    nic = get_child_or_404(get_or_404(model.Node, node), model.Nic, nic)
-    check_pending_action(nic)
-    if nic.attachments:
-        raise errors.BlockedError("Nic is connected to a network")
+    node = get_or_404(model.Node, node)
+    nic = get_child_or_404(node, model.Nic, nic)
+    if node.project:
+        raise errors.BlockedError("Nic is on a node that belongs to a project."
+                                  " Remove node from project and try again")
+    if nic.current_action:
+        db.session.delete(nic.current_action)
     db.session.delete(nic)
     db.session.commit()
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -355,9 +355,11 @@ def node_delete_nic(node, nic):
     """Delete nic with given name from it's node.
 
     If the node or nic does not exist, a NotFoundError will be raised.
+    If there's a pending networking action then a BlockedError will be raised.
     """
     get_auth_backend().require_admin()
     nic = get_child_or_404(get_or_404(model.Node, node), model.Nic, nic)
+    check_pending_action(nic)
     db.session.delete(nic)
     db.session.commit()
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -355,11 +355,15 @@ def node_delete_nic(node, nic):
     """Delete nic with given name from it's node.
 
     If the node or nic does not exist, a NotFoundError will be raised.
-    If there's a pending networking action then a BlockedError will be raised.
+    If there's a pending networking action or if the nic is connected to a
+    network then a BlockedError will be raised.
     """
+
     get_auth_backend().require_admin()
     nic = get_child_or_404(get_or_404(model.Node, node), model.Nic, nic)
     check_pending_action(nic)
+    if nic.attachments:
+        raise errors.BlockedError("Nic is connected to a network")
     db.session.delete(nic)
     db.session.commit()
 

--- a/hil/api.py
+++ b/hil/api.py
@@ -355,8 +355,8 @@ def node_delete_nic(node, nic):
     """Delete nic with given name from it's node.
 
     If the node or nic does not exist, a NotFoundError will be raised.
-    If there's a pending networking action or if the nic is connected to a
-    network then a BlockedError will be raised.
+    If the nic is on a node that belongs to a project then a BlockedError will
+    be raised.
     """
 
     get_auth_backend().require_admin()

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -577,7 +577,12 @@ class TestNodeRegisterDeleteNic:
             api.node_delete_nic('compute-02', '01-eth0')
 
     def test_node_delete_nic_after_networking_action(self, switchinit):
-        """node_delete_nic should succeed after a networking action.
+        """
+        Test node_delete_nic during various stages of a networking_action
+
+        1. Deleting a nic with a pending networking action should fail.
+        2. Deleting a nic connected to a network should fail.
+        2. Deleting a nic after the networking operation is done should work.
         """
         # 1. Create a node with a nic. Connect that nic to a switchport, and
         # add it to a project. Create a network and connect node's nic to
@@ -591,13 +596,21 @@ class TestNodeRegisterDeleteNic:
         api.node_connect_network('node-99', 'nic1', 'hammernet')
         deferred.apply_networking()
 
-        # 2. Remove node's nic from the network, and remove node from project
-        api.node_detach_network('node-99', 'nic1', 'hammernet')
-        deferred.apply_networking()
-        api.project_detach_node('anvil-nextgen', 'node-99')
+        # 2. Deleting a nic connected to a network should result in an error
+        with pytest.raises(errors.BlockedError):
+            api.node_delete_nic('node-99', 'nic1')
 
-        # 3. Remove the node from the nic and delete it.
-        api.port_detach_nic('sw0', PORTS[2])
+        # 3. Remove node's nic from the network.
+        api.node_detach_network('node-99', 'nic1', 'hammernet')
+
+        # 4. Deleting a nic that has a pending networking action should result
+        # in a BlockedError
+        with pytest.raises(errors.BlockedError):
+            api.node_delete_nic('node-99', 'nic1')
+
+        deferred.apply_networking()
+
+        # 5. Deleting the nic should work now.
         api.node_delete_nic('node-99', 'nic1')
 
     def test_node_register_nic_diff_nodes(self):


### PR DESCRIPTION
Fixes #1039 

There was one more issue with nic_delete. I added a check to make sure that we remove any networks before we are allowed to delete a nic. 

One question, administrators can delete a nic on a node that belongs to some project. Should that be allowed? Our usual policy is to disallow deletion of something that is owned by a project (networks, nodes).
