### PR TITLE
Split BlockedError to AttachedResourceError and PendingActionError

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -670,7 +670,7 @@ streaming will continue until the connection is broken.
 Only one client may be connected to a node's console in this fashion at
 a time; if a second client connects, the first will be disconnected.
 
-The node's obm must be enabled; a `BlockedError` will be raised
+The node's obm must be enabled; a `OBMError` will be raised
 otherwise.
 
 Authorization requirements:

--- a/hil/errors.py
+++ b/hil/errors.py
@@ -77,11 +77,15 @@ class AuthorizationError(APIError):
     status_code = 401
 
 
-class BlockedError(APIError):
-    """An exception indicating that the requested action cannot happen until
-    some other change.  For example, deletion is blocked until the components
-    are deleted, and possibly until the dirty flag is cleared as well.
-    """
+class AttachedResourceError(APIError):
+    """An exception indicating that there are resources still connected to
+    each other."""
+    status_code = 409  # Conflict
+
+
+class PendingActionError(APIError):
+    """An exception indicatiing that there are still processes taking place
+    on the resource."""
     status_code = 409  # Conflict
 
 

--- a/hil/ext/network_allocators/vlan_pool.py
+++ b/hil/ext/network_allocators/vlan_pool.py
@@ -5,7 +5,7 @@ import logging
 from hil.network_allocator import NetworkAllocator, set_network_allocator
 from hil.model import db
 from hil.config import cfg, core_schema, string_has_vlans
-from hil.errors import BlockedError
+from hil.errors import AllocationError
 
 from os.path import join, dirname
 from hil.migrations import paths
@@ -87,7 +87,7 @@ class VlanAllocator(NetworkAllocator):
         elif vlan.available:
             vlan.available = False
         else:
-            raise BlockedError("Network ID is not available."
+            raise AllocationError("Network ID is not available."
                                " Please choose a different ID.")
 
     def is_network_id_in_pool(self, net_id):

--- a/hil/ext/switches/common.py
+++ b/hil/ext/switches/common.py
@@ -2,7 +2,7 @@
 from hil.config import cfg
 from hil import model
 from hil.model import db
-from hil.errors import BlockedError
+from hil.errors import AttachedResourceError
 import ast
 
 
@@ -65,12 +65,12 @@ def check_native_networks(nic, op_type, channel):
        query.filter(table.channel == 'vlan/native').count() == 0:
         # checks if it is trying to attach a trunked network, and then in
         # in the db see if nic does not have any networks attached natively
-        raise BlockedError("Please attach a native network first")
+        raise AttachedResourceError("Please attach a native network first")
     elif channel == 'vlan/native' and op_type == 'detach' and \
             query.filter(table.channel != 'vlan/native').count() > 0:
         # if it is detaching a network, then check in the database if there
         # are any trunked vlans.
-        raise BlockedError("Please remove all trunked Vlans"
+        raise AttachedResourceError("Please remove all trunked Vlans"
                            " before removing the native vlan")
 
 

--- a/tests/deployment/vlan_networks.py
+++ b/tests/deployment/vlan_networks.py
@@ -97,7 +97,7 @@ class TestNetworkVlan(NetworkTest):
             # proceeding.
             if 'nativeless-trunk-mode' not in switch.get_capabilities():
                 # connecting the first network as tagged should raise an error
-                with pytest.raises(errors.BlockedError):
+                with pytest.raises(errors.SwitchError):
                     api.node_connect_network(nodes[1].label,
                                              nodes[1].nics[0].label,
                                              'net-2',

--- a/tests/integration/obmd.py
+++ b/tests/integration/obmd.py
@@ -81,7 +81,7 @@ def test_enable_disable_obm(mock_node):
     api.node_enable_disable_obm(mock_node, enabled=True)
 
     # Obm is enabled; we shouldn't be able to detach the node:
-    with pytest.raises(errors.BlockedError):
+    with pytest.raises(errors.AttachedResourceError):
         api.project_detach_node('anvil-nextgen', mock_node)
 
     # ...so disable it first:
@@ -104,19 +104,19 @@ def test_power_operations(mock_node):
     i.e. power_off, power_cycle, set_bootdev, power_status
     """
     # Obm is disabled; these should all fail:
-    with pytest.raises(errors.BlockedError):
+    with pytest.raises(errors.OBMError):
         api.node_power_off(mock_node)
-    with pytest.raises(errors.BlockedError):
+    with pytest.raises(errors.OBMError):
         api.node_power_on(mock_node)
-    with pytest.raises(errors.BlockedError):
+    with pytest.raises(errors.OBMError):
         api.node_set_bootdev(mock_node, 'A')
-    with pytest.raises(errors.BlockedError):
+    with pytest.raises(errors.OBMError):
         api.node_power_cycle(mock_node, force=True)
-    with pytest.raises(errors.BlockedError):
+    with pytest.raises(errors.OBMError):
         api.node_power_cycle(mock_node, force=False)
-    with pytest.raises(errors.BlockedError):
+    with pytest.raises(errors.OBMError):
         api.node_power_status(mock_node)
-    with pytest.raises(errors.BlockedError):
+    with pytest.raises(errors.OBMError):
         api.show_console(mock_node)
 
     # Now let's enable it and try again.

--- a/tests/unit/api/auth.py
+++ b/tests/unit/api/auth.py
@@ -14,7 +14,7 @@ import json
 from hil import api, config, model, deferred
 from hil.auth import get_auth_backend
 from hil.errors import AuthorizationError, BadArgumentError, \
-    ProjectMismatchError, BlockedError
+    ProjectMismatchError, AttachedResourceError
 from hil.test_common import config_testsuite, config_merge, fresh_database, \
     with_request_context, additional_db, fail_on_log_warnings, server_init, \
     spoof_enable_obm
@@ -586,7 +586,7 @@ auth_call_params += [
     # Project tries to connect someone else's node to itself. The basic cases
     # of connecting a free node are covered by project_calls, below.
     dict(fn=api.project_connect_node,
-         error=BlockedError,
+         error=AttachedResourceError,
          admin=False,
          project='runway',
          args=['runway', 'manhattan_node_0']),

--- a/tests/unit/api/main.py
+++ b/tests/unit/api/main.py
@@ -157,7 +157,7 @@ class TestProjectCreateDelete:
 
     def test_project_delete_hasnode(self):
         """Deleting a project which has nodes should fail."""
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.project_delete('manhattan')
 
     def test_project_delete_success_nodesdeleted(self):
@@ -172,7 +172,7 @@ class TestProjectCreateDelete:
         """Deleting a project that has networks should fail."""
         api.project_create('anvil-nextgen')
         network_create_simple('hammernet', 'anvil-nextgen')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.project_delete('anvil-nextgen')
 
     def test_project_delete_success_networksdeleted(self):
@@ -186,7 +186,7 @@ class TestProjectCreateDelete:
         """Deleting a project that has headnodes should fail."""
         api.project_create('anvil-nextgen')
         api.headnode_create('hn-01', 'anvil-nextgen', 'base-headnode')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.project_delete('anvil-nextgen')
 
     def test_duplicate_project_create(self):
@@ -229,12 +229,12 @@ class TestProjectAddDeleteNetwork:
             'runway_provider')
         deferred.apply_networking()
 
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.network_revoke_project_access('runway', 'runway_provider')
 
     def test_project_remove_network_owner(self):
         """Revoking access to a network's owner should fail."""
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.network_revoke_project_access('runway', 'runway_pxe')
 
 
@@ -315,7 +315,7 @@ class TestProjectConnectDetachNode:
         api.project_create('anvil-nextgen')
 
         api.project_connect_node('anvil-oldtimer', 'node-99')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.PendingActionError):
             api.project_connect_node('anvil-nextgen', 'node-99')
 
     def test_project_detach_node(self):
@@ -357,7 +357,7 @@ class TestProjectConnectDetachNode:
         network_create_simple('hammernet', 'anvil-nextgen')
         api.port_connect_nic('sw0', PORTS[2], 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.project_detach_node('anvil-nextgen', 'node-99')
 
     def test_project_detach_node_success_nic_not_on_network(self):
@@ -501,7 +501,7 @@ class TestNodeRegisterDelete:
         """node_delete should respond with an error if the node has nics."""
         new_node('node-99')
         api.node_register_nic('node-99', 'eth0', 'DE:AD:BE:EF:20:14')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.node_delete('node-99')
 
     def test_node_delete_in_project(self):
@@ -509,7 +509,7 @@ class TestNodeRegisterDelete:
         new_node('node-99')
         api.project_create('skeleton')
         api.project_connect_node('skeleton', 'node-99')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.node_delete('node-99')
 
 
@@ -611,7 +611,7 @@ class TestNodeRegisterDeleteNic:
         api.node_register_nic('node-99', 'nic1', 'DE:AD:BE:EF:20:18')
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'node-99')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.node_delete_nic('node-99', 'nic1')
         api.project_detach_node('anvil-nextgen', 'node-99')
         api.node_delete_nic('node-99', 'nic1')
@@ -825,7 +825,7 @@ class TestNodeConnectDetachNetwork:
         api.node_connect_network('node-99', '99-eth0', 'hammernet')  # added
         deferred.apply_networking()  # added
 
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
     def test_node_connect_network_already_attached_differently(self,
@@ -845,7 +845,7 @@ class TestNodeConnectDetachNetwork:
         api.node_connect_network('node-99', '99-eth0', 'hammernet')  # added
         deferred.apply_networking()  # added
 
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.node_connect_network('node-99', '99-eth0', 'hammernet2')
 
     def test_node_detach_network_success(self, switchinit):
@@ -1431,7 +1431,7 @@ class TestNetworkCreateDelete:
         api.project_connect_node('anvil-nextgen', 'node-99')
         api.port_connect_nic('sw0', PORTS[2], 'node-99', 'eth0')
         api.node_connect_network('node-99', 'eth0', 'hammernet')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.network_delete('hammernet')
 
     def test_network_delete_headnode_on_network(self):
@@ -1441,7 +1441,7 @@ class TestNetworkCreateDelete:
         api.headnode_create('hn-0', 'anvil-nextgen', 'base-headnode')
         api.headnode_create_hnic('hn-0', 'eth0')
         api.headnode_connect_network('hn-0', 'eth0', 'hammernet')
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.AttachedResourceError):
             api.network_delete('hammernet')
 
 
@@ -1764,7 +1764,7 @@ class TestPortConnectDetachNic:
         api.project_create('anvil-nextgen')
         api.project_connect_node('anvil-nextgen', 'compute-01')
 
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.PendingActionError):
             api.port_detach_nic('sw0', PORTS[2])
 
 
@@ -2469,7 +2469,7 @@ class TestShowNetworkingAction(unittest.TestCase):
         api.node_connect_network('node-99', '99-eth0', 'hammernet')
 
         # adding another action shouldn't work unless the last one is cleared
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.PendingActionError):
             api.node_detach_network('node-99', '99-eth0', 'hammernet')
 
         # add another network operation on the same nic, the previous action

--- a/tests/unit/ext/network_allocators/vlan_pool.py
+++ b/tests/unit/ext/network_allocators/vlan_pool.py
@@ -99,9 +99,9 @@ class TestAdminCreatedNetworks():
         assert network.allocated is True
 
         # creating a network with the same network id should raise an error
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.DuplicateError):
             api.network_create('redbone', 'admin', '', 103)
-        with pytest.raises(errors.BlockedError):
+        with pytest.raises(errors.DuplicateError):
             api.network_create('starfish', 'admin', '', net_id)
 
         # free the network ids by deleting the networks

--- a/tests/unit/ext/switches/dellnos9.py
+++ b/tests/unit/ext/switches/dellnos9.py
@@ -7,7 +7,7 @@ from hil.model import db
 from hil.test_common import config_testsuite, config_merge, fresh_database, \
     fail_on_log_warnings, with_request_context, server_init, \
     network_create_simple
-from hil.errors import BlockedError
+from hil.errors import AttachedResourceError
 
 fail_on_log_warnings = pytest.fixture(autouse=True)(fail_on_log_warnings)
 fresh_database = pytest.fixture(fresh_database)
@@ -105,10 +105,10 @@ def test_ensure_legal_operations():
 
     # connecting a trunked network wihtout having a native should fail.
     # call the method directly and test the API too.
-    with pytest.raises(BlockedError):
+    with pytest.raises(AttachedResourceError):
         switch.ensure_legal_operation(nic, 'connect', 'vlan/1212')
 
-    with pytest.raises(BlockedError):
+    with pytest.raises(AttachedResourceError):
         api.node_connect_network('compute-01', 'eth0', 'hammernet', 'vlan/40')
 
     # doing these operations in the correct order, that is native network first
@@ -119,10 +119,10 @@ def test_ensure_legal_operations():
     mock_networking_action()
 
     # removing these networks in the wrong order should not work.
-    with pytest.raises(BlockedError):
+    with pytest.raises(AttachedResourceError):
         switch.ensure_legal_operation(nic, 'detach', 'vlan/native')
 
-    with pytest.raises(BlockedError):
+    with pytest.raises(AttachedResourceError):
         api.node_detach_network('compute-01', 'eth0', 'hammernet')
 
     # removing networks in the right order should work


### PR DESCRIPTION
I'm referring to issue #925 . Since there were two suggestions I am referring to the first one that was to replace ```BlockedError``` with a ```AttachedResourceError``` and ```PendingActionError```. Also I noticed that in a lot of places the two new error types wouldn't fit into that particular case so I changed them to ```OBMError```/ ```DuplicateError```, etc. Please let me know if they need to be reverted. 
Also I was kind of swaying between a couple of the error names like when a node/ network is not free. I wasn't sure if they need to be named ```PendingActionError``` or ```AttachedResourceError``` so I named them the latter for now.
One little thing I wanted to point out was that in the comments of the ```node_detach_network``` function in api.py, it mentioned it raises an error if there is a pending network action but then the error isn't raised.