### PR TITLE
Check hil.cfg permissions on startup.

### DIFF
--- a/ci/hil_install.sh
+++ b/ci/hil_install.sh
@@ -2,8 +2,10 @@
 
 # Setup configuration
 cp ci/testsuite.cfg.$DB testsuite.cfg
+chmod 0600 testsuite.cfg
 sudo cp ci/apache/hil.cfg.$DB /etc/hil.cfg
 sudo chown travis:travis /etc/hil.cfg
+sudo chmod 0600 /etc/hil.cfg
 
 # Database Setup
 if [ $DB = postgres ]; then

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -105,10 +105,12 @@ Logging level and directory can be set in the ``[general]`` section. For more
 information view `logging <logging.html>`_.
 
 
-``hil.cfg`` file contains sensitive administrative information and should not be exposed to clients or
-end users. Therefore, after placing the file at ``/etc/hil.cfg`` its
-permissions should be set to read-only and ownership set to ``${HIL_USER}``
-From source directory of hil as user root do the following::
+``hil.cfg`` file contains sensitive administrative information and should not
+be exposed to clients or end users. Accordingly, HIL checks the permissions on
+startup and refuses to run if it is accessible by any user other than its
+owner. Ideally the file should also be read-only, as write access is not
+required at runtime. From the source directory of hil as user root do the
+following::
 
     (from /root/hil)
     $ cp examples/hil.cfg /etc/hil.cfg

--- a/docs/UPGRADING.rst
+++ b/docs/UPGRADING.rst
@@ -39,8 +39,14 @@ This file describes the procedure for upgrading HIL to a new version.
 Release Notes
 -------------
 
-0.4
+0.5 (Upcoming)
 ++++++++++++++
+
+* HIL now checks the permissions of hil.cfg on startup; if they are too
+  permissive (i.e. non-owners may access the file) it will refuse to run.
+
+0.4
++++
 
 * HIL now depends on OBMd to manage obms; the built in driver support has
   been removed. Upgrading requires several steps:

--- a/hil/config.py
+++ b/hil/config.py
@@ -101,6 +101,9 @@ def load(filename='hil.cfg'):
 
     If the config file is not found, it will simply exit.
     """
+    if (os.stat(filename).st_mode & 0o077) != 0:
+        sys.exit("Config file has overly-permissive permissions; make sure "
+                 "that only the HIL user may access the file.")
     opened_file = cfg.read(filename)
     if filename not in opened_file:
         sys.exit("Config file not found. Please create hil.cfg")

--- a/tests/unit/cli.py
+++ b/tests/unit/cli.py
@@ -38,6 +38,7 @@ def make_config(request):
             'hil.ext.network_allocators.null =',
         ])
         f.write(config)
+        os.chmod('hil.cfg', 0o600)
 
     def cleanup():
         """Remove the config file, database, and temp dir."""


### PR DESCRIPTION
...and refuse to run if non-owners can access it.

Similar to CCI-MOC/obmd#31.