### PR TITLE
Implement method to shut off a port

### DIFF
--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -74,6 +74,7 @@ class Brocade(Switch, _vlan_http.Session):
     def _port_shutdown(self, interface):
         """Shuts down port"""
         payload = '<shutdown>true</shutdown>'
+        url = self._construct_url(interface)
         # accepting 409 makes it idempotent
         self._make_request('POST', url, data=payload,
                            acceptable_error_codes=(409,))
@@ -83,6 +84,7 @@ class Brocade(Switch, _vlan_http.Session):
 
         url = self._construct_url(interface)
         response = self._make_request('GET', url)
+        root = etree.fromstring(response.text)
         shutdown = root.find(self._construct_tag("shutdown"))
         if shutdown is None:
             return False
@@ -120,7 +122,7 @@ class Brocade(Switch, _vlan_http.Session):
         url = self._construct_url(interface)
 
         # Turn on port; equivalent to running `no shutdown` on the switchport
-        if self._is_interface_off:
+        if self._is_interface_off(interface):
             self._make_request('DELETE', url+"/shutdown")
 
         # Enable switching

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -73,7 +73,7 @@ class Brocade(Switch, _vlan_http.Session):
 
     def _port_shutdown(self, interface):
         """Shuts down port"""
-        payload = '<shutdown>true</shutdown'
+        payload = '<shutdown>true</shutdown>'
         # accepting 409 makes it idempotent
         self._make_request('POST', url, data=payload,
                            acceptable_error_codes=(409,))

--- a/hil/ext/switches/brocade.py
+++ b/hil/ext/switches/brocade.py
@@ -75,7 +75,8 @@ class Brocade(Switch, _vlan_http.Session):
         """Shuts down port"""
         payload = '<shutdown>true</shutdown'
         # accepting 409 makes it idempotent
-        self._make_request('POST', url, data=payload, acceptable_error_codes=(409,))
+        self._make_request('POST', url, data=payload,
+                           acceptable_error_codes=(409,))
 
     def _is_interface_off(self, interface):
         """ Returns a boolean that tells the status of a switchport"""
@@ -87,7 +88,7 @@ class Brocade(Switch, _vlan_http.Session):
             return False
         elif shutdown.text == "true":
             return True
-        else
+        else:
             raise SwitchError("Could not determine if interface is off")
 
     def _get_mode(self, interface):
@@ -267,10 +268,10 @@ class Brocade(Switch, _vlan_http.Session):
         return '%(hostname)s/rest/config/running/interface/' \
             '%(interface_type)s/%%22%(interface)s%%22%(suffix)s' \
             % {
-                  'hostname': self.hostname,
-                  'interface_type': self.interface_type,
-                  'interface': interface,
-                  'suffix': '/switchport/%s' % suffix if suffix else ''
+                'hostname': self.hostname,
+                'interface_type': self.interface_type,
+                'interface': interface,
+                'suffix': '/switchport/%s' % suffix if suffix else ''
             }
 
     @staticmethod


### PR DESCRIPTION
* This method is called by modify_port when the native vlan is removed.
It is also called by revert_port which resets the switchport state.

Doing this prevents the switchport from sitting on default VLAN 1.

The switchport is only turned on only when we need to configure a vlan. 

Closes: https://github.com/CCI-MOC/hil/issues/970


I think it's safer to turn off the switchport entirely than fiddle with `trunk-no-native-vlan` mode which depends on the NOS version.